### PR TITLE
[order] feature: upgrade `sqlx`, fix breaking changes

### DIFF
--- a/.github/workflows/orderproc-ci.yaml
+++ b/.github/workflows/orderproc-ci.yaml
@@ -38,7 +38,7 @@ jobs:
       env:
           SYS_BASE_PATH: "${{ github.workspace }}/services"
           SERVICE_BASE_PATH: "${{ github.workspace }}/services/order"
-          CONFIG_FILE_PATH: "settings/test.json"
+          CONFIG_FILE_PATH: "settings/test-inmem-only.json"
       working-directory: services/order/tests/integration
       run: |
           cargo test --test web  --  --test-threads=1

--- a/services/order/Cargo.lock
+++ b/services/order/Cargo.lock
@@ -29,18 +29,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,14 +97,14 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "atoi"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c57d12312ff59c811c0643f4d80830505833c9ffaebd193d819392b265be8e"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
@@ -184,10 +172,10 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -212,6 +200,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +222,9 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -270,7 +267,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.96",
  "syn_derive",
 ]
 
@@ -337,9 +334,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -347,14 +344,23 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation"
@@ -426,16 +432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,14 +442,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.5.1"
+name = "deadpool"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+checksum = "6541a3916932fe57768d4be0b1ffb5ec7cbf74ca8c903fdfd5c0fe8aa958f0ed"
+dependencies = [
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
- "crypto-bigint",
  "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -469,7 +485,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -495,6 +513,9 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -504,25 +525,41 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "finl_unicode"
@@ -531,10 +568,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -583,15 +637,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
-name = "futures-intrusive"
-version = "0.4.2"
+name = "futures-executor"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604f7a68fbf8103337523b1fadc8ade7361ee3f112f7c680ad179651616aed5"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
  "parking_lot",
 ]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -601,7 +672,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -623,9 +694,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -643,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -666,7 +739,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.7",
+ "ahash",
 ]
 
 [[package]]
@@ -674,18 +747,25 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
- "ahash 0.8.11",
  "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -694,7 +774,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64",
+ "base64 0.21.5",
  "bytes",
  "headers-core",
  "http",
@@ -717,9 +797,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
-]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -732,6 +815,33 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -831,40 +941,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -888,7 +970,7 @@ version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7ea04a7c5c055c175f189b6dc6ba036fd62306b58c66c9f6389036c503a3f4"
 dependencies = [
- "base64",
+ "base64 0.21.5",
  "js-sys",
  "pem",
  "ring",
@@ -908,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libm"
@@ -919,10 +1001,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.12"
+name = "libsqlite3-sys"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
@@ -947,6 +1039,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,12 +1059,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1000,16 +1096,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1102,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
@@ -1129,7 +1215,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1158,6 +1244,7 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
+ "deadpool",
  "ecommerce-common",
  "futures-util",
  "http",
@@ -1185,35 +1272,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "parking_lot"
-version = "0.11.2"
+name = "parking"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
- "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.6"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
- "instant",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
- "winapi",
+ "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pem"
@@ -1221,15 +1306,15 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
- "base64",
+ "base64 0.21.5",
  "serde",
 ]
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.3.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
@@ -1257,7 +1342,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1274,24 +1359,23 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.3.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
  "der",
  "pkcs8",
- "zeroize",
+ "spki",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
- "zeroize",
 ]
 
 [[package]]
@@ -1340,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1369,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1414,20 +1498,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
 ]
 
 [[package]]
@@ -1513,20 +1588,20 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.6.1"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
+checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
 dependencies = [
- "byteorder",
+ "const-oid",
  "digest",
  "num-bigint-dig",
  "num-integer",
- "num-iter",
  "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core",
- "smallvec",
+ "signature",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -1555,15 +1630,15 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.21"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1648,7 +1723,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1725,6 +1800,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,7 +1823,7 @@ checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.51",
  "time",
 ]
 
@@ -1756,6 +1841,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1788,115 +1876,213 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
-version = "0.5.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
 ]
 
 [[package]]
-name = "sqlformat"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
-dependencies = [
- "itertools",
- "nom",
- "unicode_categories",
-]
-
-[[package]]
 name = "sqlx"
-version = "0.6.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8de3b03a925878ed54a954f621e64bf55a3c1bd29652d0d1a17830405350188"
+checksum = "4410e73b3c0d8442c5f99b425d7a435b5ee0ae4167b3196771dd3f7a01be745f"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
 ]
 
 [[package]]
 name = "sqlx-core"
-version = "0.6.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8241483a83a3f33aa5fff7e7d9def398ff9990b2752b6c6112b83c6d246029"
+checksum = "6a007b6936676aa9ab40207cde35daab0a04b823be8ae004368c0793b96a61e0"
 dependencies = [
- "ahash 0.7.7",
- "atoi",
- "bitflags 1.3.2",
- "byteorder",
  "bytes",
  "chrono",
  "crc",
  "crossbeam-queue",
- "digest",
- "dotenvy",
  "either",
  "event-listener",
- "futures-channel",
  "futures-core",
  "futures-intrusive",
+ "futures-io",
  "futures-util",
- "generic-array",
+ "hashbrown 0.15.2",
  "hashlink",
- "hex",
- "indexmap 1.9.3",
- "itoa",
- "libc",
+ "indexmap",
  "log",
  "memchr",
- "num-bigint",
+ "native-tls",
  "once_cell",
- "paste",
  "percent-encoding",
- "rand",
- "rsa",
  "rust_decimal",
- "sha1",
+ "serde",
+ "serde_json",
  "sha2",
  "smallvec",
- "sqlformat",
- "sqlx-rt",
- "stringprep",
- "thiserror",
+ "thiserror 2.0.11",
+ "tokio",
  "tokio-stream",
+ "tracing",
  "url",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.6.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9966e64ae989e7e575b19d7265cb79d7fc3cbbdf179835cb0d716f294c2049c9"
+checksum = "3112e2ad78643fef903618d78cf0aec1cb3134b019730edb039b69eaf531f310"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9f90acc5ab146a99bf5061a7eb4976b573f560bc898ef3bf8435448dd5e7ad"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.5.0",
+ "hex",
  "once_cell",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
  "sha2",
  "sqlx-core",
- "sqlx-rt",
- "syn 1.0.109",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.96",
+ "tempfile",
+ "tokio",
  "url",
 ]
 
 [[package]]
-name = "sqlx-rt"
-version = "0.6.3"
+name = "sqlx-mysql"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804d3f245f894e61b1e6263c84b23ca675d96753b5abfd5cc8597d86806e8024"
+checksum = "4560278f0e00ce64938540546f59f590d60beee33fffbd3b9cd47851e5fff233"
 dependencies = [
- "native-tls",
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.4.1",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
  "once_cell",
- "tokio",
- "tokio-native-tls",
+ "percent-encoding",
+ "rand",
+ "rsa",
+ "rust_decimal",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.11",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b98a57f363ed6764d5b3a12bfedf62f07aa16e1856a7ddc2a0bb190a959613"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.4.1",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.11",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f85ca71d3a5b24e64e1d08dd8fe36c6c95c339a896cc33068148906784620540"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1929,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1947,7 +2133,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1964,15 +2150,16 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.4.1",
+ "getrandom",
+ "once_cell",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1981,7 +2168,16 @@ version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.51",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -1992,7 +2188,18 @@ checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2074,7 +2281,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2123,7 +2330,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -2151,7 +2358,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "base64",
+ "base64 0.21.5",
  "bitflags 2.4.1",
  "bytes",
  "futures-core",
@@ -2210,7 +2417,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2282,18 +2489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,6 +2545,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2370,7 +2571,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
@@ -2392,7 +2593,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2402,6 +2603,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "whoami"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+]
 
 [[package]]
 name = "winapi"
@@ -2449,7 +2660,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2469,17 +2689,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2490,9 +2711,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2502,9 +2723,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2514,9 +2735,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2526,9 +2753,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2538,9 +2765,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2550,9 +2777,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2562,9 +2789,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2582,26 +2809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.37",
 ]
 
 [[package]]

--- a/services/order/Cargo.toml
+++ b/services/order/Cargo.toml
@@ -43,7 +43,8 @@ ecommerce-common = {version="^0.1.0", path="../common/rust"}
 #   this issue when number of connections increases,
 # - [reference] issues 2567, discussion 3232 in sqlx github
 # - TODO, upgrade directly to v8.x 
-sqlx = {version="=0.6.3", features=["runtime-tokio-native-tls", "chrono", "decimal"]}
+sqlx = {version="=0.8.3", default-features=false, features=["any", "json", "macros", "runtime-tokio-native-tls", "chrono", "rust_decimal"]}
+deadpool = {version="^0.12", default-features=false, features=["managed", "rt_tokio_1"]}
 
 # TODO, due to hardware memory constraint, currently I do not use migrate
 # feature, instead I use external tool `liquibase` for db migration.

--- a/services/order/README.md
+++ b/services/order/README.md
@@ -149,7 +149,8 @@ SYS_BASE_PATH="${PWD}/../../.."  SERVICE_BASE_PATH="${PWD}/../.." \
 
 Note :
 - remind the option `--features mariadb` can be used for integration test, once added to the command, this option will propagate to `order` crate .
-
+- with the feature `mariadb`, the configuration file `settings/test.json` contains essential settings for mariaDB database
+- for test with in-memory data store, use the configuration file `settings/test-inmem-only.json` without the feature `mariadb`;
 
 ### Reference
 - [Web API documentation (OpenAPI v3.0 specification)](./doc/api/openapi.yaml)

--- a/services/order/settings/test-inmem-only.json
+++ b/services/order/settings/test-inmem-only.json
@@ -1,0 +1,115 @@
+{
+    "pid_file" : {
+        "web_api"     :"tmp/proc/order_itest_app_server.pid",
+        "rpc_consumer":"tmp/proc/order_itest_rpc_consumer.pid"
+    },
+    "logging" : {
+        "handlers" : [
+            {"alias": "std-output-forall",
+             "min_level": "ERROR",
+             "destination": "console"},
+            {"alias": "errlog-file-web-api",
+             "min_level": "WARNING",
+             "path": "tmp/log/test/order_app_server.err",
+             "destination": "localfs"},
+            {"alias": "errlog-file-rpc-consumer",
+             "min_level": "WARNING",
+             "path": "tmp/log/test/order_rpc_consumer.err",
+             "destination": "localfs"}
+        ],
+        "loggers" : [
+            {"alias": "order::adapter::datastore",
+             "handlers": ["std-output-forall"],
+             "level": "WARNING"},
+            {"alias": "order::adapter::datastore::sql_db",
+             "handlers": ["std-output-forall", "errlog-file-web-api"],
+             "level": "ERROR"},
+            {"alias": "order::adapter::thirdparty::base_client",
+             "handlers": ["std-output-forall"],
+             "level": "DEBUG"},
+            {"alias": "order::api::web::order",
+             "handlers": ["errlog-file-web-api"],
+             "level": "INFO"},
+            {"alias": "order::api::web::product_policy",
+             "handlers": ["errlog-file-web-api"],
+             "level": "WARNING"},
+            {"alias": "order::api::web::cart",
+             "handlers": ["std-output-forall"],
+             "level": "WARNING"},
+            {"alias": "order::api::rpc::stock_level",
+             "handlers": ["std-output-forall"],
+             "level": "INFO"},
+            {"alias": "order::api::rpc::order_status",
+             "handlers": ["errlog-file-web-api"],
+             "level": "WARNING"},
+            {"alias": "order::usecase::currency",
+             "handlers": ["std-output-forall", "errlog-file-web-api"],
+             "level": "ERROR"},
+            {"alias": "order::usecase::edit_product_policy",
+             "handlers": ["errlog-file-web-api", "std-output-forall"],
+             "level": "WARNING"},
+            {"alias": "order::usecase::edit_product_price",
+             "handlers": ["errlog-file-rpc-consumer"],
+             "level": "INFO"},
+            {"alias": "order::usecase::stock_level",
+             "handlers": ["std-output-forall"],
+             "level": "WARNING"},
+            {"alias": "order::usecase::manage_order",
+             "handlers": ["errlog-file-web-api", "std-output-forall"],
+             "level": "WARNING"},
+            {"alias": "order::usecase::manage_cart",
+             "handlers": ["errlog-file-web-api"],
+             "level": "INFO"},
+            {"alias": "rpc_consumer",
+             "handlers": ["std-output-forall", "errlog-file-rpc-consumer"],
+             "level": "INFO"},
+            {"alias": "web",
+             "handlers": ["std-output-forall"] }
+        ]
+    },
+    "listen": {
+        "port": 8013,
+        "host":"localhost",
+        "max_failures": 5,
+        "api_version": "1.2.0",
+        "cors": "common/data/cors.json",
+	"max_connections": 50,
+        "routes": [
+            {"path":"/cart/:seq_num", "handler":"retrieve_cart_lines"},
+            {"path":"/cart/:seq_num", "handler":"modify_cart_lines"},
+            {"path":"/cart/:seq_num", "handler":"discard_cart"},
+            {"path":"/policy/products", "handler":"modify_product_policy"},
+            {"path":"/order",  "handler":"create_new_order"},
+            {"path":"/order/:oid/return", "handler":"return_lines_request"},
+            {"path":"/order/:oid", "handler":"access_existing_order"}
+        ]
+    },
+    "limit_req_body_in_bytes": 10485760,
+    "num_workers": 1,
+    "stack_sz_kb": 128,
+    "data_store": [
+	{
+	    "_type": "InMemory",
+	    "alias": "store-volatile-mem",
+	    "max_items": 48
+	}
+    ],
+    "rpc": {
+	 "handler_type": "dummy"
+    },
+    "third_parties": [
+        {
+            "mode": "test",
+            "name": "OpenExchangeRates",
+            "data_src": "tests/integration/examples/3rd-party-mock-data-currency-rate.json"
+        }
+    ],
+    "auth": {
+	"keystore_url": "http://localhost:8008/jwks",
+	"update_interval_minutes": 360
+    },
+    "confidentiality": {
+	"source": "UserSpace",
+	"sys_path": "common/data/secrets.json"
+    }
+}

--- a/services/order/settings/test.json
+++ b/services/order/settings/test.json
@@ -94,7 +94,7 @@
 	    "srv_type": "MariaDB",
 	    "db_name": "test_ecommerce_order",
 	    "confidentiality_path": "backend_apps/databases/order_service",
-	    "max_conns": 3,
+	    "max_conns": 4,
 	    "acquire_timeout_secs": 10,
 	    "idle_timeout_secs": 45
 	},

--- a/services/order/src/adapter/datastore/mod.rs
+++ b/services/order/src/adapter/datastore/mod.rs
@@ -1,30 +1,63 @@
 mod in_mem;
+#[cfg(feature = "mariadb")]
 mod sql_db;
 
 use std::boxed::Box;
+use std::result::Result as DefaultResult;
 use std::sync::Arc;
 
 use ecommerce_common::confidentiality::AbstractConfidentiality;
-use ecommerce_common::config::AppDataStoreCfg;
+use ecommerce_common::config::{AppDataStoreCfg, AppDbServerCfg};
+#[cfg(not(feature = "mariadb"))]
+use ecommerce_common::error::AppErrorCode;
 use ecommerce_common::logging::{app_log_event, AppLogContext, AppLogLevel};
 
+use crate::error::AppError;
 pub use in_mem::{
     AbsDStoreFilterKeyOp, AbstInMemoryDStore, AppInMemDeleteInfo, AppInMemDstoreLock,
     AppInMemFetchKeys, AppInMemFetchedData, AppInMemFetchedSingleRow, AppInMemFetchedSingleTable,
     AppInMemUpdateData, AppInMemoryDStore,
 };
+#[cfg(feature = "mariadb")]
 pub use sql_db::AppMariaDbStore;
 
+#[cfg(not(feature = "mariadb"))]
+pub struct AppMariaDbStore {}
+
+#[cfg(not(feature = "mariadb"))]
+impl AppMariaDbStore {
+    pub fn try_build(
+        cfg: &AppDbServerCfg,
+        _confidential: Arc<Box<dyn AbstractConfidentiality>>,
+        _logctx: Arc<AppLogContext>,
+    ) -> DefaultResult<Self, AppError> {
+        let detail = format!(
+            "sql-db, type:{:?}, alias:{}",
+            cfg.srv_type,
+            cfg.alias.as_str()
+        );
+        Err(AppError {
+            code: AppErrorCode::FeatureDisabled,
+            detail: Some(detail),
+        })
+    }
+} // end of impl AppMariaDbStore
+
+#[allow(clippy::type_complexity)]
 pub(crate) fn build_context(
     logctx: Arc<AppLogContext>,
     cfg: &Vec<AppDataStoreCfg>,
     confidential: Arc<Box<dyn AbstractConfidentiality>>,
-) -> (
-    Option<Box<dyn AbstInMemoryDStore>>,
-    Option<Vec<AppMariaDbStore>>,
-) {
+) -> DefaultResult<
+    (
+        Option<Box<dyn AbstInMemoryDStore>>,
+        Option<Vec<AppMariaDbStore>>,
+    ),
+    Vec<AppError>,
+> {
     let mut inmem = None;
     let mut sqldb = None;
+    let mut errors = Vec::new();
     for c in cfg {
         match c {
             AppDataStoreCfg::InMemory(d) => {
@@ -42,11 +75,16 @@ pub(crate) fn build_context(
                         }
                         Err(e) => {
                             app_log_event!(logctx, AppLogLevel::ERROR, "{:?}", e);
+                            errors.push(e);
                         }
                     }
                 }
             }
         }
     }
-    (inmem, sqldb)
+    if errors.is_empty() {
+        Ok((inmem, sqldb))
+    } else {
+        Err(errors)
+    }
 }

--- a/services/order/src/lib.rs
+++ b/services/order/src/lib.rs
@@ -72,7 +72,8 @@ impl AppSharedState {
             log.clone(),
             &cfg.api_server.data_store,
             confidential.clone(),
-        );
+        )
+        .unwrap();
         let in_mem = in_mem.map(Arc::new);
         let sql_dbs = sql_dbs.map(|m| m.into_iter().map(Arc::new).collect());
         let ds_ctx = Arc::new(AppDataStoreContext { in_mem, sql_dbs });

--- a/services/order/src/repository/mariadb/cart.rs
+++ b/services/order/src/repository/mariadb/cart.rs
@@ -2,6 +2,7 @@ use std::result::Result as DefaultResult;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use sqlx::database::Database as AbstractDatabase;
 use sqlx::mysql::{MySqlArguments, MySqlRow};
 use sqlx::{Acquire, Arguments, Executor, IntoArguments, MySql, Row, Statement};
 
@@ -31,10 +32,10 @@ impl<'a> From<InsertUpdateTopLvlArg<'a>> for (String, MySqlArguments) {
         let sql_patt = "INSERT INTO `cart_toplvl_meta`(`usr_id`,`seq`,`title`) VALUES (?,?,?) \
                         ON DUPLICATE KEY UPDATE `title`=?";
         let mut args = MySqlArguments::default();
-        args.add(value.0.owner);
-        args.add(value.0.seq_num);
-        args.add(value.0.title.clone());
-        args.add(value.0.title.clone());
+        args.add(value.0.owner).unwrap();
+        args.add(value.0.seq_num).unwrap();
+        args.add(value.0.title.clone()).unwrap();
+        args.add(value.0.title.clone()).unwrap();
         (sql_patt.to_string(), args)
     }
 }
@@ -52,7 +53,7 @@ impl InsertLineArg {
     }
 }
 impl<'q> IntoArguments<'q, MySql> for InsertLineArg {
-    fn into_arguments(self) -> <MySql as sqlx::database::HasArguments<'q>>::Arguments {
+    fn into_arguments(self) -> <MySql as AbstractDatabase>::Arguments<'q> {
         let mut args = MySqlArguments::default();
         let (usr_id, seq_num, lines) = (self.0, self.1, self.2);
         lines
@@ -65,12 +66,12 @@ impl<'q> IntoArguments<'q, MySql> for InsertLineArg {
                     product_id,
                 } = id_;
                 let prod_typ_num: u8 = product_type.into();
-                args.add(usr_id);
-                args.add(seq_num);
-                args.add(store_id);
-                args.add(prod_typ_num.to_string());
-                args.add(product_id);
-                args.add(quantity);
+                args.add(usr_id).unwrap();
+                args.add(seq_num).unwrap();
+                args.add(store_id).unwrap();
+                args.add(prod_typ_num.to_string()).unwrap();
+                args.add(product_id).unwrap();
+                args.add(quantity).unwrap();
             })
             .count();
         args
@@ -104,7 +105,7 @@ impl UpdateLineArg {
     }
 }
 impl<'a> IntoArguments<'a, MySql> for UpdateLineArg {
-    fn into_arguments(self) -> <MySql as sqlx::database::HasArguments<'a>>::Arguments {
+    fn into_arguments(self) -> <MySql as AbstractDatabase>::Arguments<'a> {
         let mut args = MySqlArguments::default();
         let (usr_id, seq, lines) = (self.0, self.1, self.2);
         lines
@@ -112,22 +113,22 @@ impl<'a> IntoArguments<'a, MySql> for UpdateLineArg {
             .map(|line| {
                 let prod_typ_num: u8 = line.id_.product_type.clone().into();
                 let (seller, p_id, qty) = (line.id_.store_id, line.id_.product_id, line.qty_req);
-                args.add(seller);
-                args.add(prod_typ_num.to_string());
-                args.add(p_id);
-                args.add(qty);
+                args.add(seller).unwrap();
+                args.add(prod_typ_num.to_string()).unwrap();
+                args.add(p_id).unwrap();
+                args.add(qty).unwrap();
             })
             .count();
-        args.add(usr_id);
-        args.add(seq);
+        args.add(usr_id).unwrap();
+        args.add(seq).unwrap();
         lines
             .into_iter()
             .map(|line| {
                 let prod_typ_num: u8 = line.id_.product_type.clone().into();
                 let (seller, p_id) = (line.id_.store_id, line.id_.product_id);
-                args.add(seller);
-                args.add(prod_typ_num.to_string());
-                args.add(p_id);
+                args.add(seller).unwrap();
+                args.add(prod_typ_num.to_string()).unwrap();
+                args.add(p_id).unwrap();
             })
             .count();
         args
@@ -147,8 +148,8 @@ impl From<DiscardTopLvlArg> for (String, MySqlArguments) {
         let (usr_id, seq_num) = (value.0, value.1);
         let sql_patt = "DELETE FROM `cart_toplvl_meta` WHERE `usr_id`=? AND `seq`=?";
         let mut args = MySqlArguments::default();
-        args.add(usr_id);
-        args.add(seq_num);
+        args.add(usr_id).unwrap();
+        args.add(seq_num).unwrap();
         (sql_patt.to_string(), args)
     }
 }
@@ -158,8 +159,8 @@ impl From<DiscardLineArg> for (String, MySqlArguments) {
         let (usr_id, seq_num) = (value.0, value.1);
         let sql_patt = "DELETE FROM `cart_line_detail` WHERE `usr_id`=? AND `seq`=?";
         let mut args = MySqlArguments::default();
-        args.add(usr_id);
-        args.add(seq_num);
+        args.add(usr_id).unwrap();
+        args.add(seq_num).unwrap();
         (sql_patt.to_string(), args)
     }
 }
@@ -169,8 +170,8 @@ impl From<FetchTotNumLinesArg> for (String, MySqlArguments) {
         let (usr_id, seq_num) = (value.0, value.1);
         let sql_patt = "SELECT COUNT(*) FROM `cart_line_detail` WHERE `usr_id`=? AND `seq`=?";
         let mut args = MySqlArguments::default();
-        args.add(usr_id);
-        args.add(seq_num);
+        args.add(usr_id).unwrap();
+        args.add(seq_num).unwrap();
         (sql_patt.to_string(), args)
     }
 }
@@ -181,8 +182,8 @@ impl From<FetchTopLvlArg> for (String, MySqlArguments) {
         let sql_patt = "SELECT `usr_id`,`seq`,`title` FROM `cart_toplvl_meta` \
                         WHERE `usr_id`=? AND `seq`=?";
         let mut args = MySqlArguments::default();
-        args.add(usr_id);
-        args.add(seq_num);
+        args.add(usr_id).unwrap();
+        args.add(seq_num).unwrap();
         (sql_patt.to_string(), args)
     }
 }
@@ -204,19 +205,19 @@ impl FetchLinesArg {
     }
 }
 impl<'a> IntoArguments<'a, MySql> for FetchLinesArg {
-    fn into_arguments(self) -> <MySql as sqlx::database::HasArguments<'a>>::Arguments {
+    fn into_arguments(self) -> <MySql as AbstractDatabase>::Arguments<'a> {
         let (usr_id, seq_num, opt_pids) = (self.0, self.1, self.2);
         let mut args = MySqlArguments::default();
-        args.add(usr_id);
-        args.add(seq_num);
+        args.add(usr_id).unwrap();
+        args.add(seq_num).unwrap();
         if let Some(pids) = opt_pids {
             pids.into_iter()
                 .map(|id_| {
                     let prod_typ_num: u8 = id_.product_type.into();
                     let (seller, p_id) = (id_.store_id, id_.product_id);
-                    args.add(seller);
-                    args.add(prod_typ_num.to_string());
-                    args.add(p_id);
+                    args.add(seller).unwrap();
+                    args.add(prod_typ_num.to_string()).unwrap();
+                    args.add(p_id).unwrap();
                 })
                 .count();
         }
@@ -256,7 +257,9 @@ impl TryFrom<MySqlRow> for CartLineModel {
     type Error = AppError;
     fn try_from(row: MySqlRow) -> DefaultResult<Self, Self::Error> {
         let store_id = row.try_get::<u32, usize>(0)?;
-        let product_type = row.try_get::<&str, usize>(1)?.parse::<ProductType>()?;
+        let prodtyp_raw = row.try_get::<&[u8], usize>(1)?;
+        let prodtyp_raw = std::str::from_utf8(prodtyp_raw).unwrap();
+        let product_type = prodtyp_raw.parse::<ProductType>()?;
         let product_id = row.try_get::<u64, usize>(2)?;
         let qty_req = row.try_get::<u32, usize>(3)?;
         Ok(Self {

--- a/services/order/src/repository/mariadb/stock.rs
+++ b/services/order/src/repository/mariadb/stock.rs
@@ -7,7 +7,7 @@ use std::vec::Vec;
 
 use async_trait::async_trait;
 use chrono::{DateTime, FixedOffset, NaiveDateTime};
-use sqlx::database::HasArguments;
+use sqlx::database::Database as AbstractDatabase;
 use sqlx::mysql::{MySqlArguments, MySqlRow};
 use sqlx::{Arguments, Connection, Executor, IntoArguments, MySql, Row, Statement, Transaction};
 
@@ -57,7 +57,7 @@ impl InsertQtyArg {
     }
 }
 impl<'q> IntoArguments<'q, MySql> for InsertQtyArg {
-    fn into_arguments(self) -> <MySql as HasArguments<'q>>::Arguments {
+    fn into_arguments(self) -> <MySql as AbstractDatabase>::Arguments<'q> {
         let mut out = MySqlArguments::default();
         self.0
             .into_iter()
@@ -70,12 +70,12 @@ impl<'q> IntoArguments<'q, MySql> for InsertQtyArg {
                     p.quantity.cancelled,
                 );
                 let prod_typ_num: u8 = p_typ.into();
-                out.add(store_id);
-                out.add(prod_typ_num.to_string());
-                out.add(prod_id);
-                out.add(expiry);
-                out.add(q_total);
-                out.add(q_cancelled);
+                out.add(store_id).unwrap();
+                out.add(prod_typ_num.to_string()).unwrap();
+                out.add(prod_id).unwrap();
+                out.add(expiry).unwrap();
+                out.add(q_total).unwrap();
+                out.add(q_cancelled).unwrap();
             })
             .count();
         out
@@ -113,7 +113,7 @@ impl UpdateQtyArg {
     }
 }
 impl<'q> IntoArguments<'q, MySql> for UpdateQtyArg {
-    fn into_arguments(self) -> <MySql as HasArguments<'q>>::Arguments {
+    fn into_arguments(self) -> <MySql as AbstractDatabase>::Arguments<'q> {
         let mut out = MySqlArguments::default();
         self.0
             .iter()
@@ -125,11 +125,11 @@ impl<'q> IntoArguments<'q, MySql> for UpdateQtyArg {
                     p.quantity.total,
                 );
                 let prod_typ_num: u8 = p_typ.into();
-                out.add(store_id);
-                out.add(prod_typ_num.to_string());
-                out.add(prod_id);
-                out.add(expiry);
-                out.add(q_total);
+                out.add(store_id).unwrap();
+                out.add(prod_typ_num.to_string()).unwrap();
+                out.add(prod_id).unwrap();
+                out.add(expiry).unwrap();
+                out.add(q_total).unwrap();
             })
             .count();
         self.0
@@ -142,11 +142,11 @@ impl<'q> IntoArguments<'q, MySql> for UpdateQtyArg {
                     p.quantity.cancelled,
                 );
                 let prod_typ_num: u8 = p_typ.into();
-                out.add(store_id);
-                out.add(prod_typ_num.to_string());
-                out.add(prod_id);
-                out.add(expiry);
-                out.add(q_cancelled);
+                out.add(store_id).unwrap();
+                out.add(prod_typ_num.to_string()).unwrap();
+                out.add(prod_id).unwrap();
+                out.add(expiry).unwrap();
+                out.add(q_cancelled).unwrap();
             })
             .count();
         self.0
@@ -155,10 +155,10 @@ impl<'q> IntoArguments<'q, MySql> for UpdateQtyArg {
                 let (expiry, p_typ, prod_id) =
                     (p.expiry_without_millis().naive_utc(), p.type_, p.id_);
                 let prod_typ_num: u8 = p_typ.into();
-                out.add(store_id);
-                out.add(prod_typ_num.to_string());
-                out.add(prod_id);
-                out.add(expiry);
+                out.add(store_id).unwrap();
+                out.add(prod_typ_num.to_string()).unwrap();
+                out.add(prod_id).unwrap();
+                out.add(expiry).unwrap();
             })
             .count();
         out
@@ -214,11 +214,11 @@ impl ReserveArg {
                     p.quantity.booked,
                 );
                 let prod_typ_num: u8 = p_typ.into();
-                out.add(store_id);
-                out.add(prod_typ_num.to_string());
-                out.add(prod_id);
-                out.add(expiry);
-                out.add(q_booked);
+                out.add(store_id).unwrap();
+                out.add(prod_typ_num.to_string()).unwrap();
+                out.add(prod_id).unwrap();
+                out.add(expiry).unwrap();
+                out.add(q_booked).unwrap();
             })
             .count();
         stores
@@ -230,10 +230,10 @@ impl ReserveArg {
                     p.id_,
                 );
                 let prod_typ_num: u8 = p_typ.into();
-                out.add(store_id);
-                out.add(prod_typ_num.to_string());
-                out.add(prod_id);
-                out.add(expiry);
+                out.add(store_id).unwrap();
+                out.add(prod_typ_num.to_string()).unwrap();
+                out.add(prod_id).unwrap();
+                out.add(expiry).unwrap();
             })
             .count();
         out
@@ -250,15 +250,15 @@ impl ReserveArg {
                     p.quantity.rsv_detail.unwrap(),
                 );
                 let prod_typ_num: u8 = p_typ.into();
-                out.add(store_id);
-                out.add(prod_typ_num.to_string());
-                out.add(prod_id);
-                out.add(expiry);
+                out.add(store_id).unwrap();
+                out.add(prod_typ_num.to_string()).unwrap();
+                out.add(prod_id).unwrap();
+                out.add(expiry).unwrap();
                 let (oid, rsv_per_item) = (detail.oid, detail.reserved);
                 // TODO, move to beginning of `reserve()`
                 let oid_b = OidBytes::try_from(oid.as_str()).unwrap();
-                out.add(oid_b.as_column());
-                out.add(rsv_per_item);
+                out.add(oid_b.as_column()).unwrap();
+                out.add(rsv_per_item).unwrap();
             })
             .count();
         out
@@ -305,14 +305,14 @@ impl ReturnArg {
                 let _rsv_detail = p.quantity.rsv_detail.as_ref().unwrap();
                 let qty_rsv_o = _rsv_detail.reserved;
                 let prod_typ_num: u8 = p_typ.into();
-                out.add(store_id);
-                out.add(prod_typ_num.to_string());
-                out.add(prod_id);
-                out.add(expiry);
-                out.add(qty_rsv_o);
+                out.add(store_id).unwrap();
+                out.add(prod_typ_num.to_string()).unwrap();
+                out.add(prod_id).unwrap();
+                out.add(expiry).unwrap();
+                out.add(qty_rsv_o).unwrap();
             })
             .count();
-        out.add(oid_b.as_column());
+        out.add(oid_b.as_column()).unwrap();
         self.0
             .iter()
             .map(|(store_id, p)| {
@@ -322,10 +322,10 @@ impl ReturnArg {
                     p.id_,
                 );
                 let prod_typ_num: u8 = p_typ.into();
-                out.add(store_id);
-                out.add(prod_typ_num.to_string());
-                out.add(prod_id);
-                out.add(expiry);
+                out.add(store_id).unwrap();
+                out.add(prod_typ_num.to_string()).unwrap();
+                out.add(prod_id).unwrap();
+                out.add(expiry).unwrap();
             })
             .count();
         out
@@ -360,7 +360,7 @@ impl FetchQtyArg {
     }
 }
 impl<'q> IntoArguments<'q, MySql> for FetchQtyArg {
-    fn into_arguments(self) -> <MySql as HasArguments<'q>>::Arguments {
+    fn into_arguments(self) -> <MySql as AbstractDatabase>::Arguments<'q> {
         let mut out = MySqlArguments::default();
         self.0
             .into_iter()
@@ -368,10 +368,10 @@ impl<'q> IntoArguments<'q, MySql> for FetchQtyArg {
                 let expiry = co.expiry_without_millis().naive_utc();
                 let (store_id, p_typ, prod_id) = (co.store_id, co.product_type, co.product_id);
                 let prod_typ_num: u8 = p_typ.into();
-                out.add(store_id);
-                out.add(prod_typ_num.to_string());
-                out.add(prod_id);
-                out.add(expiry);
+                out.add(store_id).unwrap();
+                out.add(prod_typ_num.to_string()).unwrap();
+                out.add(prod_id).unwrap();
+                out.add(expiry).unwrap();
             })
             .count();
         out
@@ -399,15 +399,15 @@ impl<'a> FetchQtyForRsvArg<'a> {
     }
 }
 impl<'a, 'q> IntoArguments<'q, MySql> for FetchQtyForRsvArg<'a> {
-    fn into_arguments(self) -> <MySql as HasArguments<'q>>::Arguments {
+    fn into_arguments(self) -> <MySql as AbstractDatabase>::Arguments<'q> {
         let mut out = MySqlArguments::default();
         self.0
             .iter()
             .map(|o| {
                 let prod_typ_num: u8 = o.id_.product_type.clone().into();
-                out.add(o.id_.store_id);
-                out.add(prod_typ_num.to_string());
-                out.add(o.id_.product_id);
+                out.add(o.id_.store_id).unwrap();
+                out.add(prod_typ_num.to_string()).unwrap();
+                out.add(o.id_.product_id).unwrap();
             })
             .count();
         out
@@ -439,17 +439,17 @@ impl<'a> FetchRsvOrderArg<'a> {
     }
 }
 impl<'a, 'q> IntoArguments<'q, MySql> for FetchRsvOrderArg<'a> {
-    fn into_arguments(self) -> <MySql as HasArguments<'q>>::Arguments {
+    fn into_arguments(self) -> <MySql as AbstractDatabase>::Arguments<'q> {
         let (oid_b, items) = (self.0, self.1);
         let mut out = MySqlArguments::default();
-        out.add(oid_b.as_column());
+        out.add(oid_b.as_column()).unwrap();
         items
             .iter()
             .map(|o| {
                 let prod_typ_num: u8 = o.product_type.clone().into();
-                out.add(o.store_id);
-                out.add(prod_typ_num.to_string());
-                out.add(o.product_id);
+                out.add(o.store_id).unwrap();
+                out.add(prod_typ_num.to_string()).unwrap();
+                out.add(o.product_id).unwrap();
             })
             .count();
         out
@@ -518,7 +518,9 @@ impl TryInto<ProductStockModel> for StkProdRow {
     type Error = AppError;
     fn try_into(self) -> DefaultResult<ProductStockModel, Self::Error> {
         let row = self.0;
-        let prod_typ = row.try_get::<&str, usize>(1)?.parse::<ProductType>()?;
+        let prodtyp_raw = row.try_get::<&[u8], usize>(1)?;
+        let prodtyp_raw = std::str::from_utf8(prodtyp_raw).unwrap();
+        let prod_typ = prodtyp_raw.parse::<ProductType>()?;
         let prod_id = row.try_get::<u64, usize>(2)?;
         let expiry = row.try_get::<NaiveDateTime, usize>(3)?.and_utc();
         let total = row.try_get::<u32, usize>(4)?;
@@ -546,7 +548,9 @@ impl TryInto<ProductStockModel> for StkRsvDetailRow {
     type Error = AppError;
     fn try_into(self) -> DefaultResult<ProductStockModel, Self::Error> {
         let row = self.0;
-        let prod_typ = row.try_get::<&str, usize>(1)?.parse::<ProductType>()?;
+        let prodtyp_raw = row.try_get::<&[u8], usize>(1)?;
+        let prodtyp_raw = std::str::from_utf8(prodtyp_raw).unwrap();
+        let prod_typ = prodtyp_raw.parse::<ProductType>()?;
         let prod_id = row.try_get::<u64, usize>(2)?;
         let expiry = row.try_get::<NaiveDateTime, usize>(3)?.and_utc();
         let rsv_detail = {
@@ -653,7 +657,8 @@ impl AbsOrderStockRepo for StockMariaDbRepo {
         cb: AppStockRepoReturnUserFunc,
         data: StockLevelReturnDto,
     ) -> DefaultResult<Vec<StockReturnErrorDto>, AppError> {
-        let mut conn = self._db.acquire().await?;
+        let mut objconn = self._db.acquire().await?;
+        let conn = objconn.as_mut();
         let mut tx = conn.begin().await?;
         let mut mset = {
             let oid_b = OidBytes::try_from(data.order_id.as_str())?;

--- a/services/order/tests/integration/Cargo.lock
+++ b/services/order/tests/integration/Cargo.lock
@@ -29,18 +29,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "atoi"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c57d12312ff59c811c0643f4d80830505833c9ffaebd193d819392b265be8e"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
@@ -159,7 +147,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -177,7 +165,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -209,6 +197,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -327,14 +318,23 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation"
@@ -401,16 +401,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,14 +411,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.5.1"
+name = "deadpool"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+checksum = "6541a3916932fe57768d4be0b1ffb5ec7cbf74ca8c903fdfd5c0fe8aa958f0ed"
+dependencies = [
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
- "crypto-bigint",
  "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -447,7 +457,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -473,6 +485,9 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -491,10 +506,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
+name = "etcetera"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -503,10 +534,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -555,15 +603,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
-name = "futures-intrusive"
-version = "0.4.2"
+name = "futures-executor"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604f7a68fbf8103337523b1fadc8ade7361ee3f112f7c680ad179651616aed5"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
  "parking_lot",
 ]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -595,9 +660,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -638,17 +705,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.11",
- "allocator-api2",
+ "ahash",
 ]
 
 [[package]]
@@ -656,14 +713,19 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -695,15 +757,51 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
-]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -803,31 +901,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -883,6 +962,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +1000,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,12 +1020,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -963,16 +1056,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1049,6 +1132,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1207,7 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
+ "deadpool",
  "ecommerce-common",
  "futures-util",
  "http",
@@ -1158,35 +1252,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "parking_lot"
-version = "0.11.2"
+name = "parking"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
- "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.6"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
- "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -1200,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.3.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
@@ -1247,24 +1339,23 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.3.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
  "der",
  "pkcs8",
- "zeroize",
+ "spki",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
- "zeroize",
 ]
 
 [[package]]
@@ -1373,11 +1464,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -1464,20 +1555,20 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.6.1"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
+checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
 dependencies = [
- "byteorder",
+ "const-oid",
  "digest",
  "num-bigint-dig",
  "num-integer",
- "num-iter",
  "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core",
- "smallvec",
+ "signature",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -1674,6 +1765,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,7 +1788,7 @@ checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -1705,6 +1806,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1721,114 +1825,213 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
-version = "0.5.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
 ]
 
 [[package]]
-name = "sqlformat"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
-dependencies = [
- "nom",
- "unicode_categories",
-]
-
-[[package]]
 name = "sqlx"
-version = "0.6.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8de3b03a925878ed54a954f621e64bf55a3c1bd29652d0d1a17830405350188"
+checksum = "4410e73b3c0d8442c5f99b425d7a435b5ee0ae4167b3196771dd3f7a01be745f"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
 ]
 
 [[package]]
 name = "sqlx-core"
-version = "0.6.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8241483a83a3f33aa5fff7e7d9def398ff9990b2752b6c6112b83c6d246029"
+checksum = "6a007b6936676aa9ab40207cde35daab0a04b823be8ae004368c0793b96a61e0"
 dependencies = [
- "ahash 0.7.8",
- "atoi",
- "bitflags 1.3.2",
- "byteorder",
  "bytes",
  "chrono",
  "crc",
  "crossbeam-queue",
- "digest",
- "dotenvy",
  "either",
  "event-listener",
- "futures-channel",
  "futures-core",
  "futures-intrusive",
+ "futures-io",
  "futures-util",
- "generic-array",
+ "hashbrown 0.15.2",
  "hashlink",
- "hex",
- "indexmap 1.9.3",
- "itoa",
- "libc",
+ "indexmap",
  "log",
  "memchr",
- "num-bigint",
+ "native-tls",
  "once_cell",
- "paste",
  "percent-encoding",
- "rand",
- "rsa",
  "rust_decimal",
- "sha1",
+ "serde",
+ "serde_json",
  "sha2",
  "smallvec",
- "sqlformat",
- "sqlx-rt",
- "stringprep",
- "thiserror",
+ "thiserror 2.0.11",
+ "tokio",
  "tokio-stream",
+ "tracing",
  "url",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.6.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9966e64ae989e7e575b19d7265cb79d7fc3cbbdf179835cb0d716f294c2049c9"
+checksum = "3112e2ad78643fef903618d78cf0aec1cb3134b019730edb039b69eaf531f310"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9f90acc5ab146a99bf5061a7eb4976b573f560bc898ef3bf8435448dd5e7ad"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.5.0",
+ "hex",
  "once_cell",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
  "sha2",
  "sqlx-core",
- "sqlx-rt",
- "syn 1.0.109",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.90",
+ "tempfile",
+ "tokio",
  "url",
 ]
 
 [[package]]
-name = "sqlx-rt"
-version = "0.6.3"
+name = "sqlx-mysql"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804d3f245f894e61b1e6263c84b23ca675d96753b5abfd5cc8597d86806e8024"
+checksum = "4560278f0e00ce64938540546f59f590d60beee33fffbd3b9cd47851e5fff233"
 dependencies = [
- "native-tls",
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.6.0",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
  "once_cell",
- "tokio",
- "tokio-native-tls",
+ "percent-encoding",
+ "rand",
+ "rsa",
+ "rust_decimal",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.11",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b98a57f363ed6764d5b3a12bfedf62f07aa16e1856a7ddc2a0bb190a959613"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.6.0",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.11",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f85ca71d3a5b24e64e1d08dd8fe36c6c95c339a896cc33068148906784620540"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1901,7 +2104,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -1909,6 +2121,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2045,7 +2268,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -2119,7 +2342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tracing-subscriber",
 ]
@@ -2210,18 +2433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2487,12 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -2333,6 +2550,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
+name = "whoami"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,7 +2587,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2369,7 +2605,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2378,7 +2614,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2387,15 +2638,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2405,9 +2662,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2423,9 +2692,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2435,9 +2716,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/services/order/tests/integration/web.rs
+++ b/services/order/tests/integration/web.rs
@@ -1154,11 +1154,12 @@ async fn replica_order_refund() -> DefaultResult<(), AppError> {
         StatusCode::OK,
     )
     .await;
+    let time_after_req1 = Local::now().fixed_offset();
     let resp_body = itest_setup_get_order_refund(
         shrstate.clone(),
         oid.clone(),
         time_now - Duration::seconds(2),
-        time_now + Duration::seconds(3),
+        time_after_req1,
     )
     .await;
     itest_verify_order_refund(
@@ -1183,11 +1184,12 @@ async fn replica_order_refund() -> DefaultResult<(), AppError> {
         StatusCode::OK,
     )
     .await;
+    let time_after_req2 = Local::now().fixed_offset();
     let resp_body = itest_setup_get_order_refund(
         shrstate,
         oid.clone(),
-        time_now + Duration::seconds(3),
-        time_now + Duration::seconds(3i64 + 1 + hard_limit::MIN_SECS_INTVL_REQ as i64),
+        time_after_req1,
+        time_after_req2,
     )
     .await;
     itest_verify_order_refund(
@@ -1229,10 +1231,10 @@ async fn itest_setup_get_order_inventory(
     let raw = result.unwrap();
     let result = serde_json::from_slice(&raw);
     assert!(result.is_ok());
-    println!(
-        "[debug] itest-setup-get-order-inventory , raw : {:?}",
-        String::from_utf8(raw).unwrap()
-    );
+    // println!(
+    //     "[debug] itest-setup-get-order-inventory , raw : {:?}",
+    //     String::from_utf8(raw).unwrap()
+    // );
     result.unwrap()
 } // end of fn itest_setup_get_order_inventory
 
@@ -1316,11 +1318,12 @@ async fn replica_order_rsv_inventory() -> DefaultResult<(), AppError> {
         FPATH_NEW_ORDER,
     )
     .await;
+    let time_after_req1 = Local::now().fixed_offset();
     {
         let resp_body = itest_setup_get_order_inventory(
             shrstate.clone(),
             time_now - Duration::seconds(1),
-            time_now + Duration::seconds(2),
+            time_after_req1,
         )
         .await;
         let toplvl_map = resp_body.as_object().unwrap();
@@ -1345,12 +1348,12 @@ async fn replica_order_rsv_inventory() -> DefaultResult<(), AppError> {
         StatusCode::OK,
     )
     .await;
+    let time_after_req2 = Local::now().fixed_offset();
     {
-        // Note, since all the test cases run asynchronously, the time range might be large
         let resp_body = itest_setup_get_order_inventory(
             shrstate.clone(),
             time_now - Duration::seconds(10),
-            time_now + Duration::seconds(10),
+            time_after_req2,
         )
         .await;
         let toplvl_map = resp_body.as_object().unwrap();

--- a/services/order/tests/unit/examples/config_ok_no_sqldb.json
+++ b/services/order/tests/unit/examples/config_ok_no_sqldb.json
@@ -1,0 +1,86 @@
+{
+    "pid_file" : {
+        "web_api"     :"tmp/proc/order_itest_app_server.pid",
+        "rpc_consumer":"tmp/proc/order_itest_rpc_consumer.pid"
+    },
+    "logging" : {
+        "handlers" : [
+            {"alias": "std-output-forall",
+             "min_level": "WARNING",
+             "destination": "console"},
+            {"alias": "errlog-file-web-api",
+             "min_level": "WARNING",
+             "path": "tmp/log/test/order_app_server.err",
+             "destination": "localfs"}
+        ],
+        "loggers" : [
+            {"alias": "order::adapter::datastore",
+             "handlers": ["std-output-forall"],
+             "level": "ERROR"},
+            {"alias": "order::adapter::datastore::sql_db",
+             "handlers": ["std-output-forall"],
+             "level": "ERROR"},
+            {"alias": "order::adapter::thirdparty::base_client",
+             "handlers": ["std-output-forall"],
+             "level": "INFO"},
+            {"alias": "order::usecase::stock_level",
+             "handlers": ["std-output-forall"],
+             "level": "DEBUG"},
+            {"alias": "order::usecase::manage_order",
+             "handlers": ["std-output-forall"],
+             "level": "WARNING"},
+            {"alias": "order::api::web::order",
+             "handlers": ["errlog-file-web-api"],
+             "level": "INFO"},
+            {"alias": "order::api::web::product_policy",
+             "handlers": ["errlog-file-web-api"],
+             "level": "INFO"},
+            {"alias": "web",
+             "handlers": ["std-output-forall"] }
+        ]
+    },
+    "listen": {
+        "port": 8013,
+        "host":"localhost",
+        "max_failures": 5,
+        "api_version": "1.0.33",
+        "cors": "order/tests/unit/examples/cors_ok.json",
+	"max_connections": 50,
+        "routes": [
+            {"path":"/gram/increment", "handler":"gram_increment"},
+            {"path":"/policy/products", "handler":"modify_product_policy"},
+            {"path":"/order",  "handler":"create_new_order"},
+            {"path":"/order/:oid", "handler":"access_existing_order"}
+        ]
+    },
+    "limit_req_body_in_bytes": 10485760,
+    "num_workers": 1,
+    "stack_sz_kb": 128,
+    "data_store": [
+	{
+	    "_type": "InMemory",
+	    "alias": "keep-123-mem",
+	    "max_items": 99
+	}
+    ],
+    "rpc": {
+	 "handler_type": "dummy"
+    },
+    "auth": {
+	"keystore_url": "http://localhost:12345",
+	"update_interval_minutes": 15
+    },
+    "third_parties": [
+        {
+            "name": "OpenExchangeRates",
+            "mode": "dev",
+            "host": "openexchangerates.org",
+            "port": 443,
+	        "confidentiality_path": "backend_apps/secret_key/staff/OpenExchangeRates"
+        }
+    ],
+    "confidentiality": {
+	"source": "UserSpace",
+	"sys_path": "/path/to/secret.file"
+    }
+}

--- a/services/order/tests/unit/network.rs
+++ b/services/order/tests/unit/network.rs
@@ -61,7 +61,7 @@ fn ut_service_req_setup(method: &str, uri: &str) -> Request<HyperBody> {
 #[tokio::test]
 async fn app_web_service_ok() {
     type UTestHttpBody = HyperBody;
-    let shr_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let shr_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let cfg = shr_state.config().clone();
     let rtable: ApiRouteTableType<UTestHttpBody> =
         HashMap::from([("gram_increment", routing::post(ut_endpoint_handler))]);
@@ -128,7 +128,7 @@ fn middleware_cors_error_cfg() {
 #[tokio::test]
 async fn middleware_req_body_limit() {
     type UTestHttpBody = Limited<HyperBody>;
-    let shr_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let shr_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let cfg = shr_state.config().clone();
     let rtable: ApiRouteTableType<UTestHttpBody> =
         HashMap::from([("gram_increment", routing::post(ut_endpoint_handler))]);
@@ -149,7 +149,7 @@ async fn middleware_req_body_limit() {
 #[tokio::test]
 async fn middleware_shutdown_detection() {
     type UTestHttpBody = HyperBody;
-    let shr_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let shr_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let cfg = shr_state.config().clone();
     let (mock_flag, mock_num_reqs) = (shr_state.shutdown(), shr_state.num_requests());
     let rtable: ApiRouteTableType<UTestHttpBody> =

--- a/services/order/tests/unit/usecase/edit_product_price.rs
+++ b/services/order/tests/unit/usecase/edit_product_price.rs
@@ -123,7 +123,7 @@ impl MockRepository {
 
 #[tokio::test]
 async fn create_ok() {
-    let app_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let app_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let logctx = app_state.log_context().clone();
     let (mocked_store_id, mocked_currency) = (12345, CurrencyDto::TWD);
     let mocked_ppset = ProductPriceModelSet {
@@ -176,7 +176,7 @@ async fn create_ok() {
 
 #[tokio::test]
 async fn update_ok() {
-    let app_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let app_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let logctx = app_state.log_context().clone();
     let (mocked_store_id, mocked_currency) = (12345, CurrencyDto::USD);
     let mocked_ppset = ProductPriceModelSet {
@@ -281,7 +281,7 @@ async fn update_ok() {
 
 #[tokio::test]
 async fn fetch_error() {
-    let app_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let app_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let logctx = app_state.log_context().clone();
     let (mocked_store_id, expect_errmsg) = (12345, "unit-test-set-error-1");
     let mocked_currency = CurrencyDto::THB;
@@ -329,7 +329,7 @@ async fn fetch_error() {
 
 #[tokio::test]
 async fn save_error() {
-    let app_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let app_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let logctx = app_state.log_context().clone();
     let (mocked_store_id, expect_errmsg) = (12345, "unit-test-set-error-2");
     let mocked_currency = CurrencyDto::TWD;
@@ -394,7 +394,7 @@ async fn save_error() {
 
 #[tokio::test]
 async fn delete_subset_ok() {
-    let app_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let app_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let logctx = app_state.log_context().clone();
     let mocked_store_id = 12345;
     let mocked_ppset = ProductPriceModelSet {
@@ -422,7 +422,7 @@ async fn delete_subset_ok() {
 
 #[tokio::test]
 async fn delete_subset_error() {
-    let app_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let app_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let logctx = app_state.log_context().clone();
     let (mocked_store_id, expect_errmsg) = (12345, "unit-test-set-error-1");
     let mocked_ppset = ProductPriceModelSet {
@@ -463,7 +463,7 @@ async fn delete_subset_error() {
 
 #[tokio::test]
 async fn delete_all_ok() {
-    let app_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let app_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let logctx = app_state.log_context().clone();
     let mocked_store_id = 12345;
     let mocked_ppset = ProductPriceModelSet {

--- a/services/order/tests/unit/usecase/manage_order.rs
+++ b/services/order/tests/unit/usecase/manage_order.rs
@@ -289,7 +289,7 @@ async fn create_order_snapshot_currency_err() {
     )
     .await;
     assert!(result.is_err());
-    if let Err(CreateOrderUsKsErr::Server(es)) = result {
+    if let Err(es) = result {
         assert_eq!(es.len(), 2);
         es.into_iter()
             .map(|e| {

--- a/services/order/tests/unit/usecase/manage_order.rs
+++ b/services/order/tests/unit/usecase/manage_order.rs
@@ -407,7 +407,7 @@ async fn discard_unpaid_items_common(
     stock_return_results: Vec<DefaultResult<Vec<StockReturnErrorDto>, AppError>>,
     fetched_ol_sets: Vec<OrderLineModelSet>,
 ) -> DefaultResult<(), AppError> {
-    let shr_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let shr_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let logctx = shr_state.log_context().clone();
     let not_impl_err = AppError {
         detail: None,
@@ -536,7 +536,7 @@ async fn return_lines_request_common(
     req_usr_id: u32,
     owner_usr_id: u32,
 ) -> DefaultResult<ReturnLinesReqUcOutput, AppError> {
-    let shr_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let shr_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let logctx = shr_state.log_context().clone();
     let mocked_seller_ids = fetched_olines
         .iter()
@@ -682,7 +682,7 @@ async fn replica_inventory_common(
 
 #[tokio::test]
 async fn replica_inventory_ok() {
-    let shr_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let shr_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let logctx = shr_state.log_context().clone();
     let fetched_olines = ut_setup_orderlines();
     let fetched_oids_ctime = vec!["order739".to_string()];
@@ -728,7 +728,7 @@ async fn replica_inventory_ok() {
 
 #[tokio::test]
 async fn replica_inventory_err() {
-    let shr_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let shr_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let logctx = shr_state.log_context().clone();
     let fetched_olines = ut_setup_orderlines();
     let fetched_oids_ctime = vec!["order739".to_string()];

--- a/services/order/tests/unit/usecase/mod.rs
+++ b/services/order/tests/unit/usecase/mod.rs
@@ -681,7 +681,7 @@ async fn server_run_rpc_ok() {
         _ctx.mock_recv_req(m).await;
         Arc::new(Box::new(_ctx))
     };
-    let shr_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let shr_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let result = rctx
         .server_start(shr_state, mock_route_handler_ok_wrapper)
         .await;
@@ -708,7 +708,7 @@ fn mock_route_handler_fail_wrapper(
 }
 #[tokio::test]
 async fn server_run_rpc_receive_request_error() {
-    let shr_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let shr_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let rctx: Arc<Box<dyn AbstractRpcContext>> = {
         let cfg = AppRpcCfg::dummy;
         let _ctx = MockRpcContext::_build(&cfg);

--- a/services/order/tests/unit/usecase/stock_level.rs
+++ b/services/order/tests/unit/usecase/stock_level.rs
@@ -47,7 +47,7 @@ fn ut_setup_data() -> Vec<InventoryEditStockLevelDto> {
 
 #[tokio::test]
 async fn edit_ok() {
-    let app_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let app_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let init_data = ut_setup_data();
     let expect_fetch_res = Ok(StockLevelModelSet {
         stores: vec![StoreStockModel {
@@ -83,7 +83,7 @@ async fn edit_ok() {
 
 #[tokio::test]
 async fn edit_fetch_error() {
-    let app_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let app_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let init_data = ut_setup_data();
     let expect_fetch_res = Err(AppError {
         code: AppErrorCode::DataCorruption,
@@ -115,7 +115,7 @@ async fn edit_fetch_error() {
 
 #[tokio::test]
 async fn edit_save_error() {
-    let app_state = ut_setup_share_state("config_ok.json", Box::new(MockConfidential {}));
+    let app_state = ut_setup_share_state("config_ok_no_sqldb.json", Box::new(MockConfidential {}));
     let init_data = ut_setup_data();
     let expect_fetch_res = Ok(StockLevelModelSet {
         stores: vec![StoreStockModel {


### PR DESCRIPTION
- upgrade `sqlx` from v0.6.3 to v0.8.3
- since v0.7.x, sqlx pool fails to recycle conenctions from application and reports timeout error when acquiring  new one
- current workaround is to build pool using another crate `deadpool` for proper recycle operation
- sqlx v0.8.x provides raw bytes as fetched enum column from database ; while previously in v0.6.x it provides string type, extra data type converting is essential.
- replace trait `HasArguments` with `Database` in `sqlx`
- fix lint warnings due to signature change of `MySqlArguments::add()`

TODO
- switch back to sqlx pool if future version resolves this timeout issue