### PR TITLE
[media] bugfix: fix memory errors in internal libh2o structures of app server

### DIFF
--- a/.github/workflows/media-ci.yaml
+++ b/.github/workflows/media-ci.yaml
@@ -1,8 +1,8 @@
 name: media continuous integration
 on:
-  #push:
-  #  branches:
-  #    - 'media-dev/experiment/**'
+  push:
+    branches:
+      - 'media-dev/experiment/**'
   pull_request:
     branches:
       - 'master'

--- a/.github/workflows/media-ci.yaml
+++ b/.github/workflows/media-ci.yaml
@@ -1,8 +1,8 @@
 name: media continuous integration
 on:
-  push:
-    branches:
-      - 'media-dev/experiment/**'
+  # push:
+  #   branches:
+  #     - 'media-dev/experiment/**'
   pull_request:
     branches:
       - 'master'
@@ -113,29 +113,29 @@ jobs:
             key: prebuilt-libuv
 
 
-      #- name: restore libh2o library from cache
-      #  id:   cachelibh2o
-      #  uses: actions/cache/restore@v4
-      #  with:
-      #      path: |
-      #          ${{ env.BROTLI_INSTALL_PATH }}
-      #          ${{ env.H2O_INSTALL_PATH }}
-      #      key: prebuilt-h2o-0002
+      - name: restore libh2o library from cache
+        id:   cachelibh2o
+        uses: actions/cache/restore@v4
+        with:
+            path: |
+                ${{ env.BROTLI_INSTALL_PATH }}
+                ${{ env.H2O_INSTALL_PATH }}
+            key: prebuilt-h2o-0003
 
       - name: download HTTP h2o source
-        #if: steps.cachelibh2o.outputs.cache-hit != 'true'
+        if: steps.cachelibh2o.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
         with:
             repository: metalalive/h2o # h2o/h2o
             # always clone from master branch, libh2o maintainers no longer use release tags / branches
-            # , without versioning tags, every commit might be breaking change
+            # , however without versioning tags, every commit might contain breaking change
             
             #ref: 93f4294757bb4c06e0a738b877b0a4c931a8922f
             ref: b49276113a92d6866d0e09d8dafb11341647bebe
             path: deps/h2o
 
       - name: build brotli from source as H2O dependency
-        #if: steps.cachelibh2o.outputs.cache-hit != 'true'
+        if: steps.cachelibh2o.outputs.cache-hit != 'true'
         working-directory: deps/h2o/deps/brotli
         run: |
             mkdir -p ./build && cd build
@@ -149,7 +149,7 @@ jobs:
             ls -lt ./  ./lib
 
       - name: build libh2o from source
-        #if: steps.cachelibh2o.outputs.cache-hit != 'true'
+        if: steps.cachelibh2o.outputs.cache-hit != 'true'
         working-directory: deps/h2o
         env:
             PKG_CONFIG_PATH: "${{ env.LIBUV_INSTALL_PATH }}/lib/pkgconfig:${{ env.BROTLI_INSTALL_PATH }}/lib/pkgconfig"
@@ -166,14 +166,14 @@ jobs:
         run: |
             ls -lt ./  ./lib
 
-      #- name: save libh2o library to cache
-      #  if: steps.cachelibh2o.outputs.cache-hit != 'true'
-      #  uses: actions/cache/save@v4
-      #  with:
-      #      path: |
-      #          ${{ env.BROTLI_INSTALL_PATH }}
-      #          ${{ env.H2O_INSTALL_PATH }}
-      #      key: prebuilt-h2o-0002
+      - name: save libh2o library to cache
+        if: steps.cachelibh2o.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+            path: |
+                ${{ env.BROTLI_INSTALL_PATH }}
+                ${{ env.H2O_INSTALL_PATH }}
+            key: prebuilt-h2o-0003
 
 
       - name: restore jansson library from cache

--- a/.github/workflows/media-ci.yaml
+++ b/.github/workflows/media-ci.yaml
@@ -113,27 +113,29 @@ jobs:
             key: prebuilt-libuv
 
 
-      - name: restore libh2o library from cache
-        id:   cachelibh2o
-        uses: actions/cache/restore@v4
-        with:
-            path: |
-                ${{ env.BROTLI_INSTALL_PATH }}
-                ${{ env.H2O_INSTALL_PATH }}
-            key: prebuilt-h2o-0002
+      #- name: restore libh2o library from cache
+      #  id:   cachelibh2o
+      #  uses: actions/cache/restore@v4
+      #  with:
+      #      path: |
+      #          ${{ env.BROTLI_INSTALL_PATH }}
+      #          ${{ env.H2O_INSTALL_PATH }}
+      #      key: prebuilt-h2o-0002
 
       - name: download HTTP h2o source
-        if: steps.cachelibh2o.outputs.cache-hit != 'true'
+        #if: steps.cachelibh2o.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
         with:
-            repository: h2o/h2o
+            repository: metalalive/h2o # h2o/h2o
             # always clone from master branch, libh2o maintainers no longer use release tags / branches
             # , without versioning tags, every commit might be breaking change
-            ref: 93f4294757bb4c06e0a738b877b0a4c931a8922f
+            
+            #ref: 93f4294757bb4c06e0a738b877b0a4c931a8922f
+            ref: b49276113a92d6866d0e09d8dafb11341647bebe
             path: deps/h2o
 
       - name: build brotli from source as H2O dependency
-        if: steps.cachelibh2o.outputs.cache-hit != 'true'
+        #if: steps.cachelibh2o.outputs.cache-hit != 'true'
         working-directory: deps/h2o/deps/brotli
         run: |
             mkdir -p ./build && cd build
@@ -147,7 +149,7 @@ jobs:
             ls -lt ./  ./lib
 
       - name: build libh2o from source
-        if: steps.cachelibh2o.outputs.cache-hit != 'true'
+        #if: steps.cachelibh2o.outputs.cache-hit != 'true'
         working-directory: deps/h2o
         env:
             PKG_CONFIG_PATH: "${{ env.LIBUV_INSTALL_PATH }}/lib/pkgconfig:${{ env.BROTLI_INSTALL_PATH }}/lib/pkgconfig"
@@ -164,14 +166,14 @@ jobs:
         run: |
             ls -lt ./  ./lib
 
-      - name: save libh2o library to cache
-        if: steps.cachelibh2o.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-            path: |
-                ${{ env.BROTLI_INSTALL_PATH }}
-                ${{ env.H2O_INSTALL_PATH }}
-            key: prebuilt-h2o-0002
+      #- name: save libh2o library to cache
+      #  if: steps.cachelibh2o.outputs.cache-hit != 'true'
+      #  uses: actions/cache/save@v4
+      #  with:
+      #      path: |
+      #          ${{ env.BROTLI_INSTALL_PATH }}
+      #          ${{ env.H2O_INSTALL_PATH }}
+      #      key: prebuilt-h2o-0002
 
 
       - name: restore jansson library from cache

--- a/services/media/settings/test.json
+++ b/services/media/settings/test.json
@@ -46,7 +46,7 @@
     },
     "max_connections": 64,
     "limit_req_body_in_bytes": 10485760,
-    "num_workers": 0,
+    "num_workers": 1,
     "tcp_fastopen_queue_size": 104,
     "auth_keystore": {
         "url":"https://localhost:8008/jwks",

--- a/services/media/test/integration/api/initiate_multipart_upload.c
+++ b/services/media/test/integration/api/initiate_multipart_upload.c
@@ -153,9 +153,7 @@ TestSuite *api_initiate_multipart_upload_tests(json_t *root_cfg)
     TestSuite *suite = create_test_suite();
     add_test(suite, api_test_initiate_multipart_upload_auth_token_fail);
     add_test(suite, api_test_initiate_multipart_upload_insufficient_permission);
-#ifdef PROCEED_TRANSCODING_TEST 
     add_test(suite, api_test_initiate_multipart_upload_ok);
-#endif 
     return suite;
 } // end of  api_initiate_multipart_upload_tests
 

--- a/services/media/test/integration/api/initiate_multipart_upload.c
+++ b/services/media/test/integration/api/initiate_multipart_upload.c
@@ -153,7 +153,9 @@ TestSuite *api_initiate_multipart_upload_tests(json_t *root_cfg)
     TestSuite *suite = create_test_suite();
     add_test(suite, api_test_initiate_multipart_upload_auth_token_fail);
     add_test(suite, api_test_initiate_multipart_upload_insufficient_permission);
+#ifdef PROCEED_TRANSCODING_TEST 
     add_test(suite, api_test_initiate_multipart_upload_ok);
+#endif 
     return suite;
 } // end of  api_initiate_multipart_upload_tests
 

--- a/services/media/test/integration/api/upload_part.c
+++ b/services/media/test/integration/api/upload_part.c
@@ -59,10 +59,10 @@ Ensure(api_test_upload_part__singlechunk_ok) {
     json_array_append_new(header_kv_serials, json_string("Accept:application/json"));
     {
         json_t *item = json_object();
-        json_object_set(item, "app_code", json_integer(APP_CODE));
-        json_object_set(item, "mat_code", json_integer(QUOTA_MATERIAL__MAX_UPLOAD_KBYTES_PER_USER));
-        json_object_set(item, "maxnum", json_integer(200));
-        json_array_append(quota, item);
+        json_object_set_new(item, "app_code", json_integer(APP_CODE));
+        json_object_set_new(item, "mat_code", json_integer(QUOTA_MATERIAL__MAX_UPLOAD_KBYTES_PER_USER));
+        json_object_set_new(item, "maxnum", json_integer(200));
+        json_array_append_new(quota, item);
     }
     add_auth_token_to_http_header(header_kv_serials, usr_id, codename_list, quota);
     test_setup_pub_t  setup_data = {
@@ -80,6 +80,7 @@ Ensure(api_test_upload_part__singlechunk_ok) {
     //  previously uploaded part and update the database table.
     json_decref(header_kv_serials);
     json_decref(quota);
+    free(setup_data.upload_filepaths.entries);
 } // end of api_test_upload_part__singlechunk_ok
 #undef EXPECT_PART
 #undef CHUNK_FILE_PATH
@@ -168,10 +169,10 @@ Ensure(api_test_upload_part__invalid_req) {
     json_array_append_new(header_kv_serials, json_string("Accept:application/json"));
     {
         json_t *item = json_object();
-        json_object_set(item, "app_code", json_integer(APP_CODE));
-        json_object_set(item, "mat_code", json_integer(QUOTA_MATERIAL__MAX_UPLOAD_KBYTES_PER_USER));
-        json_object_set(item, "maxnum", json_integer(1));
-        json_array_append(quota, item);
+        json_object_set_new(item, "app_code", json_integer(APP_CODE));
+        json_object_set_new(item, "mat_code", json_integer(QUOTA_MATERIAL__MAX_UPLOAD_KBYTES_PER_USER));
+        json_object_set_new(item, "maxnum", json_integer(1));
+        json_array_append_new(quota, item);
     }
     add_auth_token_to_http_header(header_kv_serials, usr_id, codename_list, quota);
     test_setup_pub_t  setup_data = {
@@ -234,6 +235,7 @@ Ensure(api_test_upload_part__quota_exceed) {
     } // end of loop
     json_decref(header_kv_serials);
     json_decref(quota);
+    free(setup_data.upload_filepaths.entries);
 } // end of api_test_upload_part__quota_exceed
 #undef  CHUNK_FILE_PATH_1  
 #undef  CHUNK_FILE_PATH_2  
@@ -340,6 +342,8 @@ done:
     json_decref(usr_upload_quota);
     if(_itest_filechunk_metadata)
         free(_itest_filechunk_metadata);
+    if(setup_data.upload_filepaths.entries)
+        free(setup_data.upload_filepaths.entries);
 } // end of api_test_upload_part__multichunk_outoforder
 
 

--- a/services/media/test/integration/main.c
+++ b/services/media/test/integration/main.c
@@ -107,9 +107,9 @@ TestSuite *app_api_tests(json_t *root_cfg)
 {
     TestSuite *suite = create_test_suite();
     add_suite(suite, api_initiate_multipart_upload_tests(root_cfg));
-#ifdef PROCEED_TRANSCODING_TEST 
     add_suite(suite, api_upload_part_tests(root_cfg));
     add_suite(suite, api_complete_multipart_upload_tests());
+#ifdef PROCEED_TRANSCODING_TEST 
     add_suite(suite, api_file_acl_tests());
     add_suite(suite, api_start_transcoding_file_tests());
     add_suite(suite, api_monitor_job_progress_tests());


### PR DESCRIPTION
Fix memory leak in following places
- on libuv h2o timer of h2o http2 connection object
- clear buffers / allocators in the libh2o internal

TODO
- `buffer_recycle_bins` in `libh2o` always reserves 12 pointers to `h2o_mem_recycle_t` object for internal use, these objects are never deallocated during entire application runtime, should free them on deinit