### PR TITLE
[product] feature: add last-update field to saleable item and rpc endpoint

### DIFF
--- a/services/product/v2/README.md
+++ b/services/product/v2/README.md
@@ -63,6 +63,13 @@ APP_SETTINGS="settings.development" poetry run granian --host 127.0.0.1 --port 8
     --interface asgi  product.entry.web:app
 ```
 
+### RPC consumer
+```bash
+SERVICE_BASE_PATH="${PWD}/../.."  poetry run celery --app=ecommerce_common.util  \
+    --config=settings.development  --workdir ./src  worker --concurrency 1 --loglevel=INFO \
+    --hostname=productmgt@%h  -E
+```
+
 ## Test
 ```bash
 APP_SETTINGS="settings.test"  ./run_unit_test

--- a/services/product/v2/doc/api/openapi.yaml
+++ b/services/product/v2/doc/api/openapi.yaml
@@ -572,6 +572,10 @@ components:
           items:
             type: string
             example: "media456"
+        last_update:
+          type: string
+          format: datetime
+          example: "2014-06-29 15:22:58"
       required:
         - id_
         - name
@@ -580,6 +584,7 @@ components:
         - tags
         - attributes
         - media_set
+        - last_update
 
   securitySchemes:
     BearerAuth:

--- a/services/product/v2/poetry.lock
+++ b/services/product/v2/poetry.lock
@@ -1394,13 +1394,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.48"
+version = "3.0.50"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
-python-versions = ">=3.7.0"
+python-versions = ">=3.8.0"
 files = [
-    {file = "prompt_toolkit-3.0.48-py3-none-any.whl", hash = "sha256:f49a827f90062e411f1ce1f854f2aedb3c23353244f8108b89283587397ac10e"},
-    {file = "prompt_toolkit-3.0.48.tar.gz", hash = "sha256:d6623ab0477a80df74e646bdbc93621143f5caf104206aa29294d53de1a03d90"},
+    {file = "prompt_toolkit-3.0.50-py3-none-any.whl", hash = "sha256:9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198"},
+    {file = "prompt_toolkit-3.0.50.tar.gz", hash = "sha256:544748f3860a2623ca5cd6d2795e7a14f3d0e1c3c9728359013f79877fc89bab"},
 ]
 
 [package.dependencies]
@@ -1833,13 +1833,13 @@ files = [
 
 [[package]]
 name = "tzdata"
-version = "2024.2"
+version = "2025.1"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 files = [
-    {file = "tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"},
-    {file = "tzdata-2024.2.tar.gz", hash = "sha256:7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc"},
+    {file = "tzdata-2025.1-py2.py3-none-any.whl", hash = "sha256:7e127113816800496f027041c570f50bcd464a020098a3b6b199517772303639"},
+    {file = "tzdata-2025.1.tar.gz", hash = "sha256:24894909e88cdb28bd1636c6887801df64cb485bd593f2fd83ef29075a81d694"},
 ]
 
 [[package]]
@@ -2042,4 +2042,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12.0"
-content-hash = "35054c7ccb4f51b4809842ea66d2c2bf0e8fe0c7ad37d6c8865850d5817a82db"
+content-hash = "9c98d4515f92d01c70a6952b31342ef408946b88a5c0141ed946ab6ccad98920"

--- a/services/product/v2/pyproject.toml
+++ b/services/product/v2/pyproject.toml
@@ -16,6 +16,7 @@ elasticsearch-curator = {git = "https://github.com/metalalive/curator.git",  bra
 aiohttp = "~3.10.0"
 PyJWT = "^2.10.0"
 cryptography = "^44.0.0"
+celery = "^5.4.0"
 ecommerce-common = {path = "../../common/python"}
 my-c-extension-lib = {path = "../../common/python/c_exts"}
 

--- a/services/product/v2/settings/celeryconfig.py
+++ b/services/product/v2/settings/celeryconfig.py
@@ -1,0 +1,50 @@
+import os
+from pathlib import Path
+from ecommerce_common.util import _get_amqp_url
+
+imports = ["product.api.rpc"]
+# data transfer between clients (producers) and workers (consumers)
+# needs to be serialized.
+task_serializer = "json"
+result_serializer = "json"
+
+timezone = "Asia/Taipei"
+
+srv_basepath = Path(os.environ["SYS_BASE_PATH"]).resolve(strict=True)
+secrets_fullpath = os.path.join(srv_basepath, "./common/data/secrets.json")
+broker_url = _get_amqp_url(secrets_path=secrets_fullpath, idx=0)
+# send result as transient message back to caller from AMQP broker,
+# instead of storing it somewhere (e.g. database, file system)
+result_backend = "rpc://"
+# set False as transient message, if set True, then the message will NOT be
+# lost after broker restarts.
+result_persistent = False
+# default expiration time in seconds, should depend on different tasks
+result_expires = 120
+
+task_queues = {}
+task_routes = {}
+task_track_started = True
+# note the default is 24 hours
+result_expires = 12
+
+
+def init_rpc(app):
+    import kombu
+    from ecommerce_common.util.messaging.constants import (
+        RPC_EXCHANGE_DEFAULT_NAME,
+        RPC_EXCHANGE_DEFAULT_TYPE,
+    )
+
+    exchange = kombu.Exchange(
+        name=RPC_EXCHANGE_DEFAULT_NAME, type=RPC_EXCHANGE_DEFAULT_TYPE
+    )
+    # determine a list of task queues used at here, you don't need to
+    # give option -Q at Celery command line
+    app.conf.task_queues = [
+        kombu.Queue(
+            "rpc_productmgt_get_product",
+            exchange=exchange,
+            routing_key="rpc.product.get_product",
+        ),
+    ]

--- a/services/product/v2/settings/common.py
+++ b/services/product/v2/settings/common.py
@@ -49,7 +49,7 @@ DATABASES = {
         "timeout_secs": 45,
         "num_conns": 7,
         "db_names": {
-            "latest": "product-saleable-items",
+            "latest": "product-saleable-items-v0.0.1",
             "history": "product-saleable-items-snapshot-%s",
         },
     },

--- a/services/product/v2/settings/development.py
+++ b/services/product/v2/settings/development.py
@@ -1,4 +1,5 @@
 from .common import *  # noqa: F403
+from .celeryconfig import *  # noqa: F403
 
 DATABASES["confidential_path"] = (  # noqa: F405
     "backend_apps.databases.product_dev_service_v2"

--- a/services/product/v2/settings/test.py
+++ b/services/product/v2/settings/test.py
@@ -1,4 +1,5 @@
 from .common import *  # noqa: F403
+from .celeryconfig import *  # noqa: F403
 
 DATABASES["confidential_path"] = (  # noqa: F405
     "backend_apps.databases.product_test_service_v2"

--- a/services/product/v2/src/product/adapter/repository/__init__.py
+++ b/services/product/v2/src/product/adapter/repository/__init__.py
@@ -19,7 +19,8 @@ class AppRepoFnLabel(Enum):
     SaleItemCreate = auto()
     SaleItemDelete = auto()
     SaleItemArchiveUpdate = auto()
-    SaleItemFetchModel = auto()
+    SaleItemFetchOneModel = auto()
+    SaleItemFetchManyModel = auto()
     SaleItemGetMaintainer = auto()
     SaleItemNumCreated = auto()
     SaleItemSearch = auto()
@@ -94,6 +95,16 @@ class AbstractSaleItemRepo:
         self, id_: int, visible_only: Optional[bool] = None
     ) -> SaleableItemModel:
         raise NotImplementedError("AbstractSaleItemRepo.fetch")
+
+    # TODO, optional timestamp to retrieve snapshot
+
+    async def fetch_many(
+        self,
+        ids: List[int],
+        usrprof: int,
+        visible_only: Optional[bool] = None,
+    ) -> List[SaleableItemModel]:
+        raise NotImplementedError("AbstractSaleItemRepo.fetch_many")
 
     async def get_maintainer(self, id_: int) -> int:
         raise NotImplementedError("AbstractSaleItemRepo.get_maintainer")

--- a/services/product/v2/src/product/adapter/repository/elasticsearch/saleable_item.py
+++ b/services/product/v2/src/product/adapter/repository/elasticsearch/saleable_item.py
@@ -142,7 +142,7 @@ class ElasticSearchSaleItemRepo(AbstractSaleItemRepo):
         list(map(cvt_attri, raw["attributes"]))
 
     async def do_archive(self, saleitem_id: int):
-        olditem_rawdoc = await self.fetch_doc_primary(
+        olditem_rawdoc = await self.fetch_doc_primary_single_id(
             id_=saleitem_id, fn_label=AppRepoFnLabel.SaleItemArchiveUpdate
         )
         snapshot_ts: str = olditem_rawdoc.pop("last_update")
@@ -185,7 +185,9 @@ class ElasticSearchSaleItemRepo(AbstractSaleItemRepo):
                 )
         _logger.debug("ElasticSearchSaleItemRepo.delete done successfully")
 
-    async def fetch_doc_primary(self, id_: int, fn_label: AppRepoFnLabel) -> Dict:
+    async def fetch_doc_primary_single_id(
+        self, id_: int, fn_label: AppRepoFnLabel
+    ) -> Dict:
         url = "/%s/the-only-type/%d" % (self._index_primary_name, id_)
         resp = await self._session.get(url)
         async with resp:
@@ -195,21 +197,26 @@ class ElasticSearchSaleItemRepo(AbstractSaleItemRepo):
                 raise AppRepoError(fn_label=fn_label, reason=respbody)
         return respbody["_source"]
 
-    async def fetch_doc_primary_visible(
-        self, id_: int, fn_label: AppRepoFnLabel
-    ) -> Dict:
+    async def fetch_doc_primary_multi_id(
+        self,
+        ids: List[int],
+        visible: Optional[bool],
+        fn_label: AppRepoFnLabel,
+        usrprof: Optional[int] = None,
+    ) -> List[Tuple[int, Dict]]:
         fields_present = ["hits.total", "hits.hits._id", "hits.hits._source", "_shards"]
         url = "/%s/the-only-type/_search?filter_path=%s" % (
             self._index_primary_name,
             ",".join(fields_present),
         )
-        reqbody = {
-            "query": {
-                "bool": {
-                    "filter": [{"ids": {"values": [id_]}}, {"term": {"visible": True}}]
-                }
-            }
-        }
+        reqbody = {"query": {"bool": {"filter": [{"ids": {"values": ids}}]}}}
+        if visible:
+            term = {"term": {"visible": True}}
+            reqbody["query"]["bool"]["filter"].append(term)
+        if usrprof is not None:
+            term = {"term": {"usr_prof": usrprof}}
+            reqbody["query"]["bool"]["filter"].append(term)
+
         headers = {"content-type": "application/json"}
         resp = await self._session.request("GET", url, json=reqbody, headers=headers)
         async with resp:
@@ -217,10 +224,8 @@ class ElasticSearchSaleItemRepo(AbstractSaleItemRepo):
             if resp.status != 200:
                 respbody["remote_database_done"] = True
                 raise AppRepoError(fn_label=fn_label, reason=respbody)
-            if respbody["hits"]["total"] != 1:
-                respbody["remote_database_done"] = True
-                raise AppRepoError(fn_label=fn_label, reason=respbody)
-        return respbody["hits"]["hits"][0]["_source"]
+        fetched_docs = respbody["hits"].get("hits", [])
+        return [(int(r["_id"]), r["_source"]) for r in fetched_docs]
 
     @staticmethod
     def convert_from_primary_doc(id_: int, raw: Dict) -> SaleableItemModel:
@@ -272,16 +277,26 @@ class ElasticSearchSaleItemRepo(AbstractSaleItemRepo):
         self, id_: int, visible_only: Optional[bool] = None
     ) -> SaleableItemModel:
         cls = type(self)
-        # TODO, optional timestamp to retrieve snapshot
         if visible_only:
-            rawdoc = await self.fetch_doc_primary_visible(
-                id_=id_,
-                fn_label=AppRepoFnLabel.SaleItemFetchModel,
+            rawdocs = await self.fetch_doc_primary_multi_id(
+                ids=[id_],
+                visible=True,
+                fn_label=AppRepoFnLabel.SaleItemFetchOneModel,
             )
+            if len(rawdocs) != 1:
+                reason = {
+                    "remote_database_done": True,
+                    "num_docs_fetched": len(rawdocs),
+                }
+                raise AppRepoError(
+                    fn_label=AppRepoFnLabel.SaleItemFetchOneModel, reason=reason
+                )
+            fetched_id, rawdoc = rawdocs[0]
+            assert fetched_id == id_
         else:
-            rawdoc = await self.fetch_doc_primary(
+            rawdoc = await self.fetch_doc_primary_single_id(
                 id_=id_,
-                fn_label=AppRepoFnLabel.SaleItemFetchModel,
+                fn_label=AppRepoFnLabel.SaleItemFetchOneModel,
             )
         try:
             obj = cls.convert_from_primary_doc(id_, rawdoc)
@@ -289,10 +304,34 @@ class ElasticSearchSaleItemRepo(AbstractSaleItemRepo):
             _logger.error("corruption detail: %s" % str(e))
             reason = {"detail": "data-corruption"}
             raise AppRepoError(
-                fn_label=AppRepoFnLabel.SaleItemFetchModel, reason=reason
+                fn_label=AppRepoFnLabel.SaleItemFetchOneModel, reason=reason
             )
         _logger.debug("ElasticSearchSaleItemRepo.fetch done successfully")
         return obj
+
+    async def fetch_many(
+        self,
+        ids: List[int],
+        usrprof: int,
+        visible_only: Optional[bool] = None,
+    ) -> List[SaleableItemModel]:
+        cls = type(self)
+        rawdocs = await self.fetch_doc_primary_multi_id(
+            ids=ids,
+            visible=visible_only,
+            usrprof=usrprof,
+            fn_label=AppRepoFnLabel.SaleItemFetchManyModel,
+        )
+        try:
+            objs = [cls.convert_from_primary_doc(id_, doc) for id_, doc in rawdocs]
+        except (ValueError, ValidationError) as e:
+            _logger.error("corruption detail: %s" % str(e))
+            reason = {"detail": "data-corruption"}
+            raise AppRepoError(
+                fn_label=AppRepoFnLabel.SaleItemFetchManyModel, reason=reason
+            )
+        _logger.debug("ElasticSearchSaleItemRepo.fetch_many done successfully")
+        return objs
 
     async def get_maintainer(self, id_: int) -> int:
         fields_present = ["_source.usr_prof", "_id"]

--- a/services/product/v2/src/product/api/dto.py
+++ b/services/product/v2/src/product/api/dto.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import Enum
 from typing import Optional, List, Union
 from pydantic import BaseModel, Field, NonNegativeInt
@@ -93,3 +94,4 @@ class SaleItemDto(BaseModel):
     tags: List[TagNodeDto]
     attributes: List[SaleItemAttriDto]
     media_set: List[str]
+    last_update: datetime

--- a/services/product/v2/src/product/api/rpc.py
+++ b/services/product/v2/src/product/api/rpc.py
@@ -8,6 +8,7 @@ from celery.backends.rpc import RPCBackend as CeleryRpcBackend
 
 from ecommerce_common.util import import_module_string
 from ecommerce_common.util.celery import app as celery_app
+from ecommerce_common.util.messaging.constants import RPC_EXCHANGE_DEFAULT_NAME
 from ecommerce_common.logging.util import log_fn_wrapper
 
 from product.adapter.repository import AbstractSaleItemRepo
@@ -18,12 +19,15 @@ evtloop = asyncio.new_event_loop()
 
 cfg_mod_path = os.getenv("CELERY_CONFIG_MODULE", "settings.common")
 _settings = import_module(cfg_mod_path)
+_settings.init_rpc(celery_app)
+
 shr_ctx_cls = import_module_string(dotted_path=_settings.SHARED_CONTEXT)
 shr_ctx = evtloop.run_until_complete(shr_ctx_cls.init(setting=_settings))
 
 
 @celery_app.task(
     backend=CeleryRpcBackend(app=celery_app),
+    exchange=RPC_EXCHANGE_DEFAULT_NAME,
     queue="rpc_productmgt_get_product",
     routing_key="rpc.product.get_product",
 )
@@ -46,7 +50,7 @@ async def get_saleitems_data(
         ids=item_ids, usrprof=profile, visible_only=True
     )
     data = [m.to_dto().model_dump() for m in ms]
-    discard_fields = ["usr_prof", "name", "visible", "tags", "media_set"]
+    discard_fields = ["usrprof", "name", "visible", "tags", "media_set"]
     # reserved fields: id_ , attributes, last_update
     for d in data:
         for fname in discard_fields:

--- a/services/product/v2/src/product/api/rpc.py
+++ b/services/product/v2/src/product/api/rpc.py
@@ -1,0 +1,54 @@
+import logging
+import os
+import asyncio
+from importlib import import_module
+from typing import Dict, List
+
+from celery.backends.rpc import RPCBackend as CeleryRpcBackend
+
+from ecommerce_common.util import import_module_string
+from ecommerce_common.util.celery import app as celery_app
+from ecommerce_common.logging.util import log_fn_wrapper
+
+from product.adapter.repository import AbstractSaleItemRepo
+from product.model import SaleableItemModel
+
+_logger = logging.getLogger(__name__)
+evtloop = asyncio.new_event_loop()
+
+cfg_mod_path = os.getenv("CELERY_CONFIG_MODULE", "settings.common")
+_settings = import_module(cfg_mod_path)
+shr_ctx_cls = import_module_string(dotted_path=_settings.SHARED_CONTEXT)
+shr_ctx = evtloop.run_until_complete(shr_ctx_cls.init(setting=_settings))
+
+
+@celery_app.task(
+    backend=CeleryRpcBackend(app=celery_app),
+    queue="rpc_productmgt_get_product",
+    routing_key="rpc.product.get_product",
+)
+@log_fn_wrapper(logger=_logger, loglevel=logging.WARNING, log_if_succeed=False)
+def get_product(item_ids: List[int], profile: int) -> Dict:
+    routine = get_saleitems_data(
+        item_ids, profile, repo=shr_ctx.datastore.saleable_item
+    )
+    result = evtloop.run_until_complete(routine)
+    return {"result": result}
+
+
+async def get_saleitems_data(
+    item_ids: List[int],
+    profile: int,
+    repo: AbstractSaleItemRepo,
+) -> List[Dict]:
+    item_ids = list(set(item_ids))
+    ms: List[SaleableItemModel] = await repo.fetch_many(
+        ids=item_ids, usrprof=profile, visible_only=True
+    )
+    data = [m.to_dto().model_dump() for m in ms]
+    discard_fields = ["usr_prof", "name", "visible", "tags", "media_set"]
+    # reserved fields: id_ , attributes, last_update
+    for d in data:
+        for fname in discard_fields:
+            d.pop(fname)
+    return data

--- a/services/product/v2/src/product/migrations/elastic_curator/saleable_item/action_0002.yaml
+++ b/services/product/v2/src/product/migrations/elastic_curator/saleable_item/action_0002.yaml
@@ -1,0 +1,96 @@
+actions:
+  1:
+    action: create_index
+    description: "Create an index for storing saleable items"
+    options:
+      name: "product-saleable-items-v0.0.1"
+      continue_if_exception: False
+      disable_action: False
+      extra_settings:
+        settings:
+          number_of_shards: 1
+          number_of_replicas: 1
+        mappings:
+          the-only-type:
+            properties:
+              name:
+                type: text
+                fields:
+                  as_english:
+                    type: text
+                    analyzer: english
+              usr_prof:
+                type: integer
+              visible:
+                type: boolean
+              tags:
+                type: nested
+                properties:
+                  label:
+                    type: text
+                    fields:
+                      as_english:
+                        type: text
+                        analyzer: english
+                  node_id:
+                    type: integer
+                  tree_id:
+                    type: keyword
+              attributes:
+                type: nested
+                properties:
+                  label:
+                    type: object
+                    properties:
+                      id_:
+                        type: keyword
+                      name:
+                        type: text
+                        fields:
+                          as_english:
+                            type: text
+                            analyzer: english
+                      dtype:
+                        type: integer
+                  value:
+                    type: object
+                    properties:
+                      boolean_value:
+                        type: boolean
+                      integer_value:
+                        type: integer
+                      string_value:
+                        type: text
+                        fields:
+                          as_english:
+                            type: text
+                            analyzer: english
+              media_set:
+                type: keyword
+              last_update:
+                type: date
+                format: "yyyy-MM-dd HH:mm:ss" # auto convert to UTC timezone at app tier
+  2:
+    action: reindex
+    description: "Create an index for snapshot of saleable items at update points in time"
+    options:
+      wait_interval: 9
+      max_wait: 38
+      request_body:
+        source:
+          index: "product-saleable-items"
+        dest:
+          index: "product-saleable-items-v0.0.1"
+    filters:
+      - filtertype: none
+  3:
+    action: delete_indices
+    description: "Delete old saleable item index"
+    options:
+      timeout_override: 65
+      continue_if_exception: True
+    filters:
+      - filtertype: pattern
+        kind: regex
+        value: '^product-saleable-items$'
+

--- a/services/product/v2/src/product/model/saleable.py
+++ b/services/product/v2/src/product/model/saleable.py
@@ -44,6 +44,9 @@ class SaleItemAttriModel:
             raise AttriLabelError.invalid_data(errors)
         return objs
 
+    def to_dto(self) -> SaleItemAttriDto:
+        return SaleItemAttriDto(label=self.label.to_dto(), value=self.value)
+
 
 @dataclass
 class SaleableItemModel:
@@ -87,10 +90,7 @@ class SaleableItemModel:
             for tree_id, nodes in self.tags.items()
             for node in nodes
         ]
-        attris_d = [
-            SaleItemAttriDto(label=a.label.to_dto(), value=a.value)
-            for a in self.attributes
-        ]
+        attris_d = [a.to_dto() for a in self.attributes]
         return SaleItemDto(
             id_=self.id_,
             name=self.name,

--- a/services/product/v2/src/product/model/saleable.py
+++ b/services/product/v2/src/product/model/saleable.py
@@ -1,3 +1,4 @@
+from datetime import datetime, UTC
 from dataclasses import dataclass
 from typing import Optional, Self, Dict, List, Tuple, Union
 
@@ -53,7 +54,7 @@ class SaleableItemModel:
     tags: Dict[str, List[TagModel]]
     attributes: List[SaleItemAttriModel]
     media_set: List[str]  # List of resource IDs to external multimedia systems
-    # TODO, add timestamp field for recording last update time
+    last_update: datetime
 
     @classmethod
     def from_req(
@@ -74,6 +75,7 @@ class SaleableItemModel:
             tags=tag_ms_map,
             attributes=attri_val_ms,
             media_set=req.media_set,
+            last_update=datetime.now(UTC).replace(microsecond=0),
         )
 
     def rotate_id(self):
@@ -97,4 +99,9 @@ class SaleableItemModel:
             tags=tags_d,
             attributes=attris_d,
             media_set=self.media_set,
+            last_update=self.last_update,
         )
+
+    @staticmethod
+    def STRING_DATETIME_FORMAT():
+        return "%Y-%m-%d %H:%M:%S"

--- a/services/product/v2/tests/integration/common.py
+++ b/services/product/v2/tests/integration/common.py
@@ -30,6 +30,7 @@ def es_mapping_init():
     action_file_rel_paths = [
         "attri_label/action_0001.yaml",
         "saleable_item/action_0001.yaml",
+        "saleable_item/action_0002.yaml",
         "tag/action_0001.yaml",
     ]
 

--- a/services/product/v2/tests/unit/adapter/repository/elasticsearch/__init__.py
+++ b/services/product/v2/tests/unit/adapter/repository/elasticsearch/__init__.py
@@ -10,6 +10,7 @@ async def es_mapping_init(app_setting):
         "attri_label/action_0001.yaml",
         "tag/action_0001.yaml",
         "saleable_item/action_0001.yaml",
+        "saleable_item/action_0002.yaml",
     ]
 
     def _run_curator(relpath):

--- a/services/product/v2/tests/unit/adapter/repository/elasticsearch/action_teardown_test.yaml
+++ b/services/product/v2/tests/unit/adapter/repository/elasticsearch/action_teardown_test.yaml
@@ -8,4 +8,4 @@ actions:
     filters:
       - filtertype: pattern
         kind: regex
-        value: '^product-[tags,attribute-labels,saleable-items]'
+        value: '^product-[tags,attribute-labels,saleable-items*]'

--- a/services/product/v2/tests/unit/adapter/repository/elasticsearch/saleable_item.py
+++ b/services/product/v2/tests/unit/adapter/repository/elasticsearch/saleable_item.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import timedelta
 from typing import List, Dict, Tuple, Any, Optional
 
 import pytest
@@ -45,6 +46,7 @@ def verify_items_equlity(item1: SaleableItemModel, item2: SaleableItemModel):
     assert item1.usr_prof == item2.usr_prof
     assert item1.visible == item2.visible
     assert set(item1.media_set) == set(item2.media_set)
+    assert item1.last_update == item2.last_update
 
     expect = build_verify_tag_data(item2.tags)
     actual = build_verify_tag_data(item1.tags)
@@ -171,7 +173,7 @@ class TestCreate:
         assert another_item_created.id_ > 0
         assert another_item_created.id_ < pow(2, 64)
 
-        await asyncio.sleep(1)  # wait for ElasticSearch refresh documents
+        await asyncio.sleep(2)  # wait for ElasticSearch refresh documents
 
         num_items_saved = await es_repo_saleitem.num_items_created(
             usr_id=expect_usr_prof
@@ -219,6 +221,7 @@ class TestUpdate:
         ]
         saleitem_m.tags["xiug"].extend(new_tags)
         saleitem_m.name = "Fabulous Coat"
+        saleitem_m.last_update += timedelta(seconds=5)
         old_attr = next(
             filter(lambda a: a.label.id_ == "attr4id", saleitem_m.attributes)
         )

--- a/services/product/v2/tests/unit/adapter/repository/elasticsearch/saleable_item.py
+++ b/services/product/v2/tests/unit/adapter/repository/elasticsearch/saleable_item.py
@@ -264,7 +264,7 @@ class TestDelete:
         with pytest.raises(AppRepoError) as e:
             await es_repo_saleitem.fetch(saleitem_m_created.id_)
         e = e.value
-        assert e.fn_label == AppRepoFnLabel.SaleItemFetchModel
+        assert e.fn_label == AppRepoFnLabel.SaleItemFetchOneModel
         assert not e.reason["found"]
         assert int(e.reason["_id"]) == saleitem_m_created.id_
 
@@ -309,16 +309,100 @@ class TestFetchOne:
             with pytest.raises(AppRepoError) as e:
                 await es_repo_saleitem.fetch(obj.id_, visible_only=True)
             e = e.value
-            assert e.fn_label == AppRepoFnLabel.SaleItemFetchModel
+            assert e.fn_label == AppRepoFnLabel.SaleItemFetchOneModel
             assert e.reason["remote_database_done"]
             readback = await es_repo_saleitem.fetch(obj.id_, visible_only=False)
             verify_items_equlity(readback, obj)
 
 
+class TestFetchMany:
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_visibility_ok(self, es_repo_saleitem):
+        usrs_prof = [12352, 12353]
+        saleitem_ms_created = {u: [] for u in usrs_prof}
+        product_labels = [
+            "degradable Bio insect repellent",
+            "EcoGuard bug removal",
+            "BioBanish: Nature-Friendly Bug Defense",
+            "GreenShield slug Repellent",
+            "EcoDefense: Biodegradable Aphids Control",
+            "NatureSafe: Degradable Locust Repellent",
+            "BioBarrier: Planet-Friendly Pest Solution",
+            "PureProtect: Bettle Repellent",
+        ]
+        iter0 = iter(product_labels)
+
+        for usr_prof in usrs_prof:
+            for i in range(1, 5):
+                req_data = SaleItemCreateReqDto(
+                    name=next(iter0),
+                    visible=(i % 2 == 1),
+                    media_set=[f"resource-tool-{i}"],
+                    tags=[f"gardening-{i}"],
+                    attributes=[],
+                )
+                tag_data = {f"gardening-{i}": [(i, f"Tool Label {i}")]}
+                attr_data = [
+                    ("attr1", "Material", AttrDataTypeDto.String, "Jalapeno"),
+                    ("attr2", "Weight", AttrDataTypeDto.Integer, i * 2),
+                ]
+                obj = await TestCreate.setup_create_one(
+                    es_repo_saleitem,
+                    usr_prof=usr_prof,
+                    req_data=req_data,
+                    tag_data=tag_data,
+                    attr_data=attr_data,
+                )
+                saleitem_ms_created[usr_prof].append(obj)
+
+        await asyncio.sleep(2)  # Wait for ElasticSearch refresh documents
+
+        all_item_ids = [m.id_ for _, ms in saleitem_ms_created.items() for m in ms]
+        readback = await es_repo_saleitem.fetch_many(
+            all_item_ids, usrs_prof[0], visible_only=False
+        )
+        assert len(readback) == 4
+        expect_labels = product_labels[:4]
+        actual_labels = [r.name for r in readback]
+        assert set(expect_labels) == set(actual_labels)
+
+        readback = await es_repo_saleitem.fetch_many(
+            all_item_ids, usrs_prof[0], visible_only=True
+        )
+        assert len(readback) == 2
+        expect_labels = [product_labels[0], product_labels[2]]
+        actual_labels = [r.name for r in readback]
+        assert set(expect_labels) == set(actual_labels)
+
+        readback = await es_repo_saleitem.fetch_many(
+            all_item_ids, usrs_prof[1], visible_only=True
+        )
+        assert len(readback) == 2
+        expect_labels = [product_labels[4], product_labels[6]]
+        actual_labels = [r.name for r in readback]
+        assert set(expect_labels) == set(actual_labels)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_empty(self, es_repo_saleitem):
+        usr_prof = 12354
+        readback = await es_repo_saleitem.fetch_many([], usr_prof, visible_only=True)
+        assert len(readback) == 0
+        readback = await es_repo_saleitem.fetch_many([], usr_prof)
+        assert len(readback) == 0
+        readback = await es_repo_saleitem.fetch_many(
+            [5566], usr_prof, visible_only=True
+        )
+        assert len(readback) == 0
+        readback = await es_repo_saleitem.fetch_many(
+            [7788], usr_prof, visible_only=False
+        )
+        assert len(readback) == 0
+
+
 class TestSearch:
     @pytest.mark.asyncio(loop_scope="session")
     async def test_visibleonly_ok(self, es_repo_saleitem):
-        usr_prof = 12352
+        usr_prof = 12355
         tag_data = {
             "elety": [(1, "Electronics")],
             "oioiu": [(2, "smarT little things")],
@@ -394,7 +478,7 @@ class TestSearch:
             tag_data={k: v for k, v in tag_data.items() if k in ["elety", "oioiu"]},
             attr_data=attr_data_3,
         )
-        await asyncio.sleep(1)  # wait for ElasticSearch refresh documents
+        await asyncio.sleep(2)  # wait for ElasticSearch refresh documents
 
         def verify_fetched_items(expect: List, actual: List):
             expect = [(e.id_, e.name) for e in expect]

--- a/services/product/v2/tests/unit/model/saleable.py
+++ b/services/product/v2/tests/unit/model/saleable.py
@@ -1,3 +1,4 @@
+from datetime import datetime, UTC
 import pytest
 
 from product.api.dto import AttrDataTypeDto, SaleItemAttriReqDto, SaleItemCreateReqDto
@@ -68,6 +69,7 @@ class TestAttributeValue:
 
 class TestSaleableItem:
     def test_create_from_req_ok(self):
+        t0 = datetime.now(UTC).replace(second=0)
         req = SaleItemCreateReqDto(
             name="Sample Item",
             visible=True,
@@ -103,6 +105,9 @@ class TestSaleableItem:
         assert item1.tags == tag_ms_map
         assert item1.attributes == attri_val_ms
         assert item1.media_set == req.media_set
+        assert item1.last_update >= t0
+        assert item2.last_update >= t0
 
         dto2 = item2.to_dto()
         assert dto2.id_ == id_
+        assert dto2.last_update == item2.last_update


### PR DESCRIPTION
add last-update field to saleable item
- modify elasticsearch index mapping for saleable item
- the last update field can be used for other applications to specify
  which saleable item snapshot to fetch

RPC consumer for other applications verifying saleable items
- implement fetch-many method in elasticsearch repository
- the handling function of rpc consumer fetch saleable items , extract
  essential fields e.g. attributes, last-update to other applications